### PR TITLE
fix: Form invalid text internal messages for all form elements

### DIFF
--- a/src/components/reusable/checkbox/checkboxGroup.ts
+++ b/src/components/reusable/checkbox/checkboxGroup.ts
@@ -60,6 +60,20 @@ export class CheckboxGroup extends LitElement {
   @state()
   internals = this.attachInternals();
 
+  /**
+   * Internal validation message.
+   * @ignore
+   */
+  @state()
+  internalValidationMsg = '';
+
+  /**
+   * isInvalid when internalValidationMsg or invalidText is non-empty.
+   * @ignore
+   */
+  @state()
+  isInvalid = false;
+
   override render() {
     return html`
       <fieldset ?disabled=${this.disabled}>
@@ -70,11 +84,11 @@ export class CheckboxGroup extends LitElement {
 
         <slot></slot>
 
-        ${this.invalidText !== ''
+        ${this.isInvalid
           ? html`
               <div class="error">
                 <kd-icon .icon="${errorIcon}"></kd-icon>
-                ${this.invalidText}
+                ${this.invalidText || this.internalValidationMsg}
               </div>
             `
           : null}
@@ -83,6 +97,11 @@ export class CheckboxGroup extends LitElement {
   }
 
   override updated(changedProps: any) {
+    //check if any (internal / external )error msg. present then isInvalid is true
+    this.isInvalid =
+      this.invalidText !== '' || this.internalValidationMsg !== ''
+        ? true
+        : false;
     if (changedProps.has('name')) {
       // set name for each checkbox
       this.checkboxes.forEach((checkbox: any) => {
@@ -110,9 +129,10 @@ export class CheckboxGroup extends LitElement {
             { valueMissing: true },
             'A selection is required.'
           );
-          this.invalidText = this.internals.validationMessage;
+          this.internalValidationMsg = this.internals.validationMessage;
         } else {
           this.internals.setValidity({});
+          this.internalValidationMsg = '';
           this.invalidText = '';
         }
       }
@@ -131,11 +151,13 @@ export class CheckboxGroup extends LitElement {
         checkbox.disabled = this.disabled;
       });
     }
-
-    if (changedProps.has('invalidText')) {
+    if (
+      changedProps.has('invalidText') ||
+      changedProps.has('internalValidationMsg')
+    ) {
       // set invalid state for each checkbox
       this.checkboxes.forEach((checkbox: any) => {
-        checkbox.invalid = this.invalidText !== '';
+        checkbox.invalid = this.isInvalid;
       });
     }
   }

--- a/src/components/reusable/checkbox/checkboxGroup.ts
+++ b/src/components/reusable/checkbox/checkboxGroup.ts
@@ -97,11 +97,6 @@ export class CheckboxGroup extends LitElement {
   }
 
   override updated(changedProps: any) {
-    //check if any (internal / external )error msg. present then isInvalid is true
-    this.isInvalid =
-      this.invalidText !== '' || this.internalValidationMsg !== ''
-        ? true
-        : false;
     if (changedProps.has('name')) {
       // set name for each checkbox
       this.checkboxes.forEach((checkbox: any) => {
@@ -155,6 +150,10 @@ export class CheckboxGroup extends LitElement {
       changedProps.has('invalidText') ||
       changedProps.has('internalValidationMsg')
     ) {
+      this.isInvalid =
+        this.invalidText !== '' || this.internalValidationMsg !== ''
+          ? true
+          : false;
       // set invalid state for each checkbox
       this.checkboxes.forEach((checkbox: any) => {
         checkbox.invalid = this.isInvalid;

--- a/src/components/reusable/datePicker/datepicker.ts
+++ b/src/components/reusable/datePicker/datepicker.ts
@@ -96,6 +96,20 @@ export class DatePicker extends LitElement {
   @query('input')
   inputEl!: HTMLInputElement;
 
+  /**
+   * Internal validation message.
+   * @ignore
+   */
+  @state()
+  internalValidationMsg = '';
+
+  /**
+   * isInvalid when internalValidationMsg or invalidText is non-empty.
+   * @ignore
+   */
+  @state()
+  isInvalid = false;
+
   override render() {
     return html`
       <label
@@ -126,7 +140,7 @@ export class DatePicker extends LitElement {
           value=${this.value}
           ?required=${this.required}
           ?disabled=${this.disabled}
-          ?invalid=${this.invalidText !== ''}
+          ?invalid=${this.isInvalid}
           min=${ifDefined(this.minDate)}
           max=${ifDefined(this.maxDate)}
           step=${ifDefined(this.step)}
@@ -136,10 +150,10 @@ export class DatePicker extends LitElement {
       ${this.caption !== ''
         ? html` <div class="caption">${this.caption}</div> `
         : null}
-      ${this.invalidText !== ''
-        ? html` <div class="error">${this.invalidText}</div> `
+      ${this.isInvalid
+        ? html` <div class="error">${this.invalidText || this.internalValidationMsg}</div> `
         : null}
-      ${this.warnText !== '' && this.invalidText === ''
+      ${this.warnText !== '' && !this.isInvalid
         ? html`<div class="warn">${this.warnText}</div>`
         : null}
     `;
@@ -159,11 +173,14 @@ export class DatePicker extends LitElement {
   }
 
   override updated(changedProps: PropertyValues) {
+    //check if any (internal / external )error msg. present then isInvalid is true
+    this.isInvalid = this.invalidText !== '' || this.internalValidationMsg !== '' ? true : false;
     if (changedProps.has('value')) {
       this.inputEl.value = this.value;
       // set form data value
       this.internals.setFormValue(this.value);
       this.internals.setValidity({});
+      this.internalValidationMsg = '';
       this.invalidText = '';
 
       // set validity
@@ -172,7 +189,7 @@ export class DatePicker extends LitElement {
           { valueMissing: true },
           'This field is required.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
         return;
       }
       // validate min
@@ -197,14 +214,14 @@ export class DatePicker extends LitElement {
           { rangeUnderflow: true },
           'Please enter date as min date or later.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       }
     } else {
       this.internals.setValidity(
         { patternMismatch: true },
         'Please enter valid min date.'
       );
-      this.invalidText = this.internals.validationMessage;
+      this.internalValidationMsg = this.internals.validationMessage;
     }
   }
 
@@ -219,14 +236,14 @@ export class DatePicker extends LitElement {
           { rangeOverflow: true },
           'Please enter date as max date or earlier.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       }
     } else {
       this.internals.setValidity(
         { patternMismatch: true },
         'Please enter valid max date.'
       );
-      this.invalidText = this.internals.validationMessage;
+      this.internalValidationMsg = this.internals.validationMessage;
     }
   }
 }

--- a/src/components/reusable/datePicker/datepicker.ts
+++ b/src/components/reusable/datePicker/datepicker.ts
@@ -69,7 +69,7 @@ export class DatePicker extends LitElement {
 
   /** Maximum date in YYYY-MM-DD or YYYY-MM-DDThh:mm format.
    * If the value isn't a possible date string in the format, then the element has no maximum date value
-  */
+   */
   @property({ type: String })
   maxDate = '';
 
@@ -151,7 +151,11 @@ export class DatePicker extends LitElement {
         ? html` <div class="caption">${this.caption}</div> `
         : null}
       ${this.isInvalid
-        ? html` <div class="error">${this.invalidText || this.internalValidationMsg}</div> `
+        ? html`
+            <div class="error">
+              ${this.invalidText || this.internalValidationMsg}
+            </div>
+          `
         : null}
       ${this.warnText !== '' && !this.isInvalid
         ? html`<div class="warn">${this.warnText}</div>`
@@ -173,8 +177,16 @@ export class DatePicker extends LitElement {
   }
 
   override updated(changedProps: PropertyValues) {
-    //check if any (internal / external )error msg. present then isInvalid is true
-    this.isInvalid = this.invalidText !== '' || this.internalValidationMsg !== '' ? true : false;
+    if (
+      changedProps.has('invalidText') ||
+      changedProps.has('internalValidationMsg')
+    ) {
+      //check if any (internal / external )error msg. present then isInvalid is true
+      this.isInvalid =
+        this.invalidText !== '' || this.internalValidationMsg !== ''
+          ? true
+          : false;
+    }
     if (changedProps.has('value')) {
       this.inputEl.value = this.value;
       // set form data value

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -170,10 +170,15 @@ export class DateRangePicker extends LitElement {
   }
 
   override updated(changedProps: PropertyValues) {
-    this.isInvalid =
-      this.invalidText !== '' || this.internalValidationMsg !== ''
-        ? true
-        : false;
+    if (
+      changedProps.has('invalidText') ||
+      changedProps.has('internalValidationMsg')
+    ) {
+      this.isInvalid =
+        this.invalidText !== '' || this.internalValidationMsg !== ''
+          ? true
+          : false;
+    }
     if (changedProps.has('startDate')) {
       // set form data value
       this.internals.setFormValue(`${this.name}-start`, this.startDate);

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -88,6 +88,20 @@ export class DateRangePicker extends LitElement {
   @property({ type: String })
   step = '';
 
+  /**
+   * Internal validation message.
+   * @ignore
+   */
+  @state()
+  internalValidationMsg = '';
+
+  /**
+   * isInvalid when internalValidationMsg or invalidText is non-empty.
+   * @ignore
+   */
+  @state()
+  isInvalid = false;
+
   override render() {
     return html`
       <label
@@ -111,7 +125,7 @@ export class DateRangePicker extends LitElement {
           value=${this.startDate}
           ?required=${this.required}
           ?disabled=${this.disabled}
-          ?invalid=${this.invalidText !== ''}
+          ?invalid=${this.isInvalid}
           min=${ifDefined(this.minDate)}
           max=${ifDefined(this.endDate ?? this.maxDate ?? '')}
           step=${ifDefined(this.step)}
@@ -131,7 +145,7 @@ export class DateRangePicker extends LitElement {
           name="${this.name}-end"
           value=${this.endDate}
           ?disabled=${this.disabled}
-          ?invalid=${this.invalidText !== ''}
+          ?invalid=${this.isInvalid}
           min=${ifDefined(this.startDate ?? this.minDate ?? '')}
           max=${ifDefined(this.maxDate)}
           step=${ifDefined(this.step)}
@@ -142,28 +156,37 @@ export class DateRangePicker extends LitElement {
       ${this.caption !== ''
         ? html` <div class="caption">${this.caption}</div> `
         : null}
-      ${this.invalidText !== ''
-        ? html` <div class="error">${this.invalidText}</div> `
+      ${this.isInvalid
+        ? html`
+            <div class="error">
+              ${this.invalidText || this.internalValidationMsg}
+            </div>
+          `
         : null}
-      ${this.warnText !== '' && this.invalidText === ''
+      ${this.warnText !== '' && !this.isInvalid
         ? html`<div class="warn">${this.warnText}</div>`
         : null}
     `;
   }
 
   override updated(changedProps: PropertyValues) {
+    this.isInvalid =
+      this.invalidText !== '' || this.internalValidationMsg !== ''
+        ? true
+        : false;
     if (changedProps.has('startDate')) {
       // set form data value
       this.internals.setFormValue(`${this.name}-start`, this.startDate);
       this.internals.setValidity({});
       this.invalidText = '';
+      this.internalValidationMsg = '';
       // set validity
       if (this.required && (!this.startDate || this.startDate === '')) {
         this.internals.setValidity(
           { valueMissing: true },
           'Both dates are required.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
         return;
       }
       // validate min
@@ -183,13 +206,14 @@ export class DateRangePicker extends LitElement {
       this.internals.setFormValue(`${this.name}-end`, this.endDate);
       this.internals.setValidity({});
       this.invalidText = '';
+      this.internalValidationMsg = '';
       // set validity
       if (this.required && (!this.endDate || this.endDate === '')) {
         this.internals.setValidity(
           { valueMissing: true },
           'Both dates are required.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
         return;
       }
       // validate min
@@ -241,14 +265,14 @@ export class DateRangePicker extends LitElement {
           { rangeUnderflow: true },
           'Please enter date as min date or later.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       }
     } else {
       this.internals.setValidity(
         { patternMismatch: true },
         'Please enter valid min date.'
       );
-      this.invalidText = this.internals.validationMessage;
+      this.internalValidationMsg = this.internals.validationMessage;
     }
   }
   // validate maxDate with start & end date
@@ -259,14 +283,14 @@ export class DateRangePicker extends LitElement {
           { rangeOverflow: true },
           'Please enter date as max date or earlier.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       }
     } else {
       this.internals.setValidity(
         { patternMismatch: true },
         'Please enter valid max date.'
       );
-      this.invalidText = this.internals.validationMessage;
+      this.internalValidationMsg = this.internals.validationMessage;
     }
   }
 
@@ -276,7 +300,7 @@ export class DateRangePicker extends LitElement {
         { patternMismatch: true },
         'State date must be before end date.'
       );
-      this.invalidText = this.internals.validationMessage;
+      this.internalValidationMsg = this.internals.validationMessage;
     }
   }
 }

--- a/src/components/reusable/dropdown/dropdown.ts
+++ b/src/components/reusable/dropdown/dropdown.ts
@@ -684,11 +684,16 @@ export class Dropdown extends LitElement {
   }
 
   override updated(changedProps: any) {
-    //check if any (internal / external )error msg. present then isInvalid is true
-    this.isInvalid =
-      this.invalidText !== '' || this.internalValidationMsg !== ''
-        ? true
-        : false;
+    if (
+      changedProps.has('invalidText') ||
+      changedProps.has('internalValidationMsg')
+    ) {
+      //check if any (internal / external )error msg. present then isInvalid is true
+      this.isInvalid =
+        this.invalidText !== '' || this.internalValidationMsg !== ''
+          ? true
+          : false;
+    }
     if (changedProps.has('value')) {
       // close listbox
       if (!this.multiple) {

--- a/src/components/reusable/dropdown/dropdown.ts
+++ b/src/components/reusable/dropdown/dropdown.ts
@@ -151,6 +151,20 @@ export class Dropdown extends LitElement {
   @query('.options')
   listboxEl!: HTMLElement;
 
+  /**
+   * Internal validation message.
+   * @ignore
+   */
+  @state()
+  internalValidationMsg = '';
+
+  /**
+   * isInvalid when internalValidationMsg or invalidText is non-empty.
+   * @ignore
+   */
+  @state()
+  isInvalid = false;
+
   override render() {
     return html`
       <div
@@ -183,7 +197,7 @@ export class Dropdown extends LitElement {
               aria-labelledby="label-${this.name}"
               ?required=${this.required}
               ?disabled=${this.disabled}
-              ?invalid=${this.invalidText !== ''}
+              ?invalid=${this.isInvalid}
               tabindex=${this.searchable ? '-1' : '0'}
               @click=${() => this.handleClick()}
               @keydown=${(e: any) => this.handleButtonKeydown(e)}
@@ -257,7 +271,7 @@ export class Dropdown extends LitElement {
                 </button>
               `
             : null}
-          ${this.invalidText !== ''
+          ${this.isInvalid
             ? html` <kd-icon class="error-icon" .icon=${errorIcon}></kd-icon> `
             : null}
         </div>
@@ -288,8 +302,12 @@ export class Dropdown extends LitElement {
         ${this.caption !== ''
           ? html` <div class="caption">${this.caption}</div> `
           : null}
-        ${this.invalidText !== ''
-          ? html` <div class="error">${this.invalidText}</div> `
+        ${this.isInvalid
+          ? html`
+              <div class="error">
+                ${this.invalidText || this.internalValidationMsg}
+              </div>
+            `
           : null}
 
         <div
@@ -666,6 +684,11 @@ export class Dropdown extends LitElement {
   }
 
   override updated(changedProps: any) {
+    //check if any (internal / external )error msg. present then isInvalid is true
+    this.isInvalid =
+      this.invalidText !== '' || this.internalValidationMsg !== ''
+        ? true
+        : false;
     if (changedProps.has('value')) {
       // close listbox
       if (!this.multiple) {
@@ -719,9 +742,10 @@ export class Dropdown extends LitElement {
             { valueMissing: true },
             'This field is required.'
           );
-          this.invalidText = this.internals.validationMessage;
+          this.internalValidationMsg = this.internals.validationMessage;
         } else {
           this.internals.setValidity({});
+          this.internalValidationMsg = '';
           this.invalidText = '';
         }
       }

--- a/src/components/reusable/radioButton/radioButtonGroup.ts
+++ b/src/components/reusable/radioButton/radioButtonGroup.ts
@@ -60,19 +60,19 @@ export class RadioButtonGroup extends LitElement {
   @state()
   internals = this.attachInternals();
 
-    /**
+  /**
    * Internal validation message.
    * @ignore
    */
-    @state()
-    internalValidationMsg = '';
-  
-    /**
-     * isInvalid when internalValidationMsg or invalidText is non-empty.
-     * @ignore
-     */
-    @state()
-    isInvalid = false;
+  @state()
+  internalValidationMsg = '';
+
+  /**
+   * isInvalid when internalValidationMsg or invalidText is non-empty.
+   * @ignore
+   */
+  @state()
+  isInvalid = false;
 
   override render() {
     return html`
@@ -97,11 +97,11 @@ export class RadioButtonGroup extends LitElement {
   }
 
   override updated(changedProps: any) {
-     //check if any (internal / external )error msg. present then isInvalid is true
-     this.isInvalid =
-     this.invalidText !== '' || this.internalValidationMsg !== ''
-       ? true
-       : false;
+    //check if any (internal / external )error msg. present then isInvalid is true
+    this.isInvalid =
+      this.invalidText !== '' || this.internalValidationMsg !== ''
+        ? true
+        : false;
     if (changedProps.has('name')) {
       // set name for each radio button
       this.radioButtons.forEach((radio: any) => {
@@ -148,7 +148,10 @@ export class RadioButtonGroup extends LitElement {
       });
     }
 
-    if (changedProps.has('invalidText') || changedProps.has('internalValidationMsg')) {
+    if (
+      changedProps.has('invalidText') ||
+      changedProps.has('internalValidationMsg')
+    ) {
       // set invalid state for each radio button
       this.radioButtons.forEach((radio: any) => {
         radio.invalid = this.isInvalid;

--- a/src/components/reusable/radioButton/radioButtonGroup.ts
+++ b/src/components/reusable/radioButton/radioButtonGroup.ts
@@ -60,6 +60,20 @@ export class RadioButtonGroup extends LitElement {
   @state()
   internals = this.attachInternals();
 
+    /**
+   * Internal validation message.
+   * @ignore
+   */
+    @state()
+    internalValidationMsg = '';
+  
+    /**
+     * isInvalid when internalValidationMsg or invalidText is non-empty.
+     * @ignore
+     */
+    @state()
+    isInvalid = false;
+
   override render() {
     return html`
       <fieldset ?disabled=${this.disabled}>
@@ -70,11 +84,11 @@ export class RadioButtonGroup extends LitElement {
 
         <slot></slot>
 
-        ${this.invalidText !== ''
+        ${this.isInvalid
           ? html`
               <div class="error">
                 <kd-icon .icon="${errorIcon}"></kd-icon>
-                ${this.invalidText}
+                ${this.invalidText || this.internalValidationMsg}
               </div>
             `
           : null}
@@ -83,6 +97,11 @@ export class RadioButtonGroup extends LitElement {
   }
 
   override updated(changedProps: any) {
+     //check if any (internal / external )error msg. present then isInvalid is true
+     this.isInvalid =
+     this.invalidText !== '' || this.internalValidationMsg !== ''
+       ? true
+       : false;
     if (changedProps.has('name')) {
       // set name for each radio button
       this.radioButtons.forEach((radio: any) => {
@@ -106,9 +125,10 @@ export class RadioButtonGroup extends LitElement {
             { valueMissing: true },
             'This field is required.'
           );
-          this.invalidText = this.internals.validationMessage;
+          this.internalValidationMsg = this.internals.validationMessage;
         } else {
           this.internals.setValidity({});
+          this.internalValidationMsg = '';
           this.invalidText = '';
         }
       }
@@ -128,10 +148,10 @@ export class RadioButtonGroup extends LitElement {
       });
     }
 
-    if (changedProps.has('invalidText')) {
+    if (changedProps.has('invalidText') || changedProps.has('internalValidationMsg')) {
       // set invalid state for each radio button
       this.radioButtons.forEach((radio: any) => {
-        radio.invalid = this.invalidText !== '';
+        radio.invalid = this.isInvalid;
       });
     }
   }

--- a/src/components/reusable/radioButton/radioButtonGroup.ts
+++ b/src/components/reusable/radioButton/radioButtonGroup.ts
@@ -97,11 +97,6 @@ export class RadioButtonGroup extends LitElement {
   }
 
   override updated(changedProps: any) {
-    //check if any (internal / external )error msg. present then isInvalid is true
-    this.isInvalid =
-      this.invalidText !== '' || this.internalValidationMsg !== ''
-        ? true
-        : false;
     if (changedProps.has('name')) {
       // set name for each radio button
       this.radioButtons.forEach((radio: any) => {
@@ -152,6 +147,11 @@ export class RadioButtonGroup extends LitElement {
       changedProps.has('invalidText') ||
       changedProps.has('internalValidationMsg')
     ) {
+      //check if any (internal / external )error msg. present then isInvalid is true
+      this.isInvalid =
+        this.invalidText !== '' || this.internalValidationMsg !== ''
+          ? true
+          : false;
       // set invalid state for each radio button
       this.radioButtons.forEach((radio: any) => {
         radio.invalid = this.isInvalid;

--- a/src/components/reusable/textArea/textArea.ts
+++ b/src/components/reusable/textArea/textArea.ts
@@ -141,11 +141,16 @@ ${this.value}</textarea
   }
 
   override updated(changedProps: any) {
-    //check if any (internal / external )error msg. present then isInvalid is true
-    this.isInvalid =
-      this.invalidText !== '' || this.internalValidationMsg !== ''
-        ? true
-        : false;
+    if (
+      changedProps.has('invalidText') ||
+      changedProps.has('internalValidationMsg')
+    ) {
+      //check if any (internal / external )error msg. present then isInvalid is true
+      this.isInvalid =
+        this.invalidText !== '' || this.internalValidationMsg !== ''
+          ? true
+          : false;
+    }
     if (changedProps.has('value')) {
       // set form data value
       this.internals.setFormValue(this.value);

--- a/src/components/reusable/textArea/textArea.ts
+++ b/src/components/reusable/textArea/textArea.ts
@@ -66,6 +66,20 @@ export class TextArea extends LitElement {
   @property({ type: Number })
   minLength = null;
 
+  /**
+   * Internal validation message.
+   * @ignore
+   */
+  @state()
+  internalValidationMsg = '';
+
+  /**
+   * isInvalid when internalValidationMsg or invalidText is non-empty.
+   * @ignore
+   */
+  @state()
+  isInvalid = false;
+
   override render() {
     return html`
       <div class="text-area" ?disabled=${this.disabled}>
@@ -81,7 +95,7 @@ export class TextArea extends LitElement {
             placeholder=${this.placeholder}
             ?required=${this.required}
             ?disabled=${this.disabled}
-            ?invalid=${this.invalidText !== ''}
+            ?invalid=${this.isInvalid}
             minlength=${ifDefined(this.minLength)}
             maxlength=${ifDefined(this.maxLength)}
             @input=${(e: any) => this.handleInput(e)}
@@ -89,7 +103,7 @@ export class TextArea extends LitElement {
 ${this.value}</textarea
           >
 
-          ${this.invalidText !== ''
+          ${this.isInvalid
             ? html` <kd-icon class="error-icon" .icon=${errorIcon}></kd-icon> `
             : null}
           ${this.maxLength
@@ -102,8 +116,12 @@ ${this.value}</textarea
         ${this.caption !== ''
           ? html` <div class="caption">${this.caption}</div> `
           : null}
-        ${this.invalidText !== ''
-          ? html` <div class="error">${this.invalidText}</div> `
+        ${this.isInvalid
+          ? html`
+              <div class="error">
+                ${this.invalidText || this.internalValidationMsg}
+              </div>
+            `
           : null}
       </div>
     `;
@@ -123,6 +141,11 @@ ${this.value}</textarea
   }
 
   override updated(changedProps: any) {
+    //check if any (internal / external )error msg. present then isInvalid is true
+    this.isInvalid =
+      this.invalidText !== '' || this.internalValidationMsg !== ''
+        ? true
+        : false;
     if (changedProps.has('value')) {
       // set form data value
       this.internals.setFormValue(this.value);
@@ -134,18 +157,19 @@ ${this.value}</textarea
           { valueMissing: true },
           'This field is required.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       } else if (this.minLength && this.value.length < this.minLength) {
         // validate min
         this.internals.setValidity({ tooShort: true }, 'Too few characters.');
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       } else if (this.maxLength && this.value.length > this.maxLength) {
         // validate max
         this.internals.setValidity({ tooLong: true }, 'Too many characters.');
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       } else {
         // clear validation
         this.internals.setValidity({});
+        this.internalValidationMsg = '';
         this.invalidText = '';
       }
     }

--- a/src/components/reusable/textInput/textInput.ts
+++ b/src/components/reusable/textInput/textInput.ts
@@ -181,7 +181,11 @@ export class TextInput extends LitElement {
           ? html` <div class="caption">${this.caption}</div> `
           : null}
         ${this.isInvalid
-          ? html` <div class="error">${this.invalidText || this.internalValidationMsg}</div> `
+          ? html`
+              <div class="error">
+                ${this.invalidText || this.internalValidationMsg}
+              </div>
+            `
           : null}
       </div>
     `;
@@ -206,8 +210,16 @@ export class TextInput extends LitElement {
   }
 
   override updated(changedProps: any) {
-    //check if any (internal / external )error msg. present then isInvalid is true
-    this.isInvalid = this.invalidText !== '' || this.internalValidationMsg !== '' ? true : false;
+    if (
+      changedProps.has('invalidText') ||
+      changedProps.has('internalValidationMsg')
+    ) {
+      //check if any (internal / external )error msg. present then isInvalid is true
+      this.isInvalid =
+        this.invalidText !== '' || this.internalValidationMsg !== ''
+          ? true
+          : false;
+    }
     if (changedProps.has('value')) {
       this.inputEl.value = this.value;
       // set form data value
@@ -220,7 +232,7 @@ export class TextInput extends LitElement {
           { valueMissing: true },
           'This field is required.'
         );
-       this.internalValidationMsg = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       } else if (this.minLength && this.value.length < this.minLength) {
         // validate min
         this.internals.setValidity({ tooShort: true }, 'Too few characters.');

--- a/src/components/reusable/textInput/textInput.ts
+++ b/src/components/reusable/textInput/textInput.ts
@@ -113,6 +113,20 @@ export class TextInput extends LitElement {
   @queryAssignedElements({ slot: 'icon' })
   iconSlot!: Array<HTMLElement>;
 
+  /**
+   * Internal validation message.
+   * @ignore
+   */
+  @state()
+  internalValidationMsg = '';
+
+  /**
+   * isInvalid when internalValidationMsg or invalidText is non-empty.
+   * @ignore
+   */
+  @state()
+  isInvalid = false;
+
   override render() {
     return html`
       <div class="text-input" ?disabled=${this.disabled}>
@@ -144,14 +158,14 @@ export class TextInput extends LitElement {
             placeholder=${this.placeholder}
             ?required=${this.required}
             ?disabled=${this.disabled}
-            ?invalid=${this.invalidText !== ''}
+            ?invalid=${this.isInvalid}
             pattern=${ifDefined(this.pattern)}
             minlength=${ifDefined(this.minLength)}
             maxlength=${ifDefined(this.maxLength)}
             @input=${(e: any) => this.handleInput(e)}
           />
 
-          ${this.invalidText !== ''
+          ${this.isInvalid
             ? html` <kd-icon class="error-icon" .icon=${errorIcon}></kd-icon> `
             : null}
           ${this.value !== ''
@@ -166,8 +180,8 @@ export class TextInput extends LitElement {
         ${this.caption !== ''
           ? html` <div class="caption">${this.caption}</div> `
           : null}
-        ${this.invalidText !== ''
-          ? html` <div class="error">${this.invalidText}</div> `
+        ${this.isInvalid
+          ? html` <div class="error">${this.invalidText || this.internalValidationMsg}</div> `
           : null}
       </div>
     `;
@@ -192,6 +206,8 @@ export class TextInput extends LitElement {
   }
 
   override updated(changedProps: any) {
+    //check if any (internal / external )error msg. present then isInvalid is true
+    this.isInvalid = this.invalidText !== '' || this.internalValidationMsg !== '' ? true : false;
     if (changedProps.has('value')) {
       this.inputEl.value = this.value;
       // set form data value
@@ -204,15 +220,15 @@ export class TextInput extends LitElement {
           { valueMissing: true },
           'This field is required.'
         );
-        this.invalidText = this.internals.validationMessage;
+       this.internalValidationMsg = this.internals.validationMessage;
       } else if (this.minLength && this.value.length < this.minLength) {
         // validate min
         this.internals.setValidity({ tooShort: true }, 'Too few characters.');
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       } else if (this.maxLength && this.value.length > this.maxLength) {
         // validate max
         this.internals.setValidity({ tooLong: true }, 'Too many characters.');
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       } else if (
         this.pattern &&
         this.pattern != '' &&
@@ -223,10 +239,11 @@ export class TextInput extends LitElement {
           { patternMismatch: true },
           'Does not match expected format.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       } else {
         // clear validation
         this.internals.setValidity({});
+        this.internalValidationMsg = '';
         this.invalidText = '';
       }
     }

--- a/src/components/reusable/timepicker/timepicker.ts
+++ b/src/components/reusable/timepicker/timepicker.ts
@@ -99,6 +99,20 @@ export class TimePicker extends LitElement {
    */
   regexPatternWithoutSec = /^\d{2}:\d{2}$/; // hh:mm
 
+  /**
+   * Internal validation message.
+   * @ignore
+   */
+  @state()
+  internalValidationMsg = '';
+
+  /**
+   * isInvalid when internalValidationMsg or invalidText is non-empty.
+   * @ignore
+   */
+  @state()
+  isInvalid = false;
+
   override render() {
     return html`
       <div class="time-picker" ?disabled=${this.disabled}>
@@ -124,7 +138,7 @@ export class TimePicker extends LitElement {
             step=${ifDefined(this.step)}
             ?required=${this.required}
             ?disabled=${this.disabled}
-            ?invalid=${this.invalidText !== ''}
+            ?invalid=${this.isInvalid}
             min=${ifDefined(this.minTime)}
             max=${ifDefined(this.maxTime)}
             @input=${(e: any) => this.handleInput(e)}
@@ -134,10 +148,10 @@ export class TimePicker extends LitElement {
         ${this.caption !== ''
           ? html` <div class="caption">${this.caption}</div> `
           : null}
-        ${this.invalidText !== ''
-          ? html` <div class="error">${this.invalidText}</div> `
+        ${this.isInvalid
+          ? html` <div class="error">${this.invalidText || this.internalValidationMsg}</div> `
           : null}
-        ${this.warnText !== '' && this.invalidText === ''
+        ${this.warnText !== '' && !this.isInvalid
           ? html`<div class="warn">${this.warnText}</div>`
           : null}
       </div>
@@ -157,12 +171,15 @@ export class TimePicker extends LitElement {
   }
 
   override updated(changedProps: any) {
+    //check if any (internal / external )error msg. present then isInvalid is true
+    this.isInvalid = this.invalidText !== '' || this.internalValidationMsg !== '' ? true : false;
     if (changedProps.has('value')) {
       this.inputEl.value = this.value;
       //set form data value
       this.internals.setFormValue(this.value);
       this.internals.setValidity({});
       this.invalidText = '';
+      this.internalValidationMsg = '';
 
       // set validity
       if (this.required && (!this.value || this.value === '')) {
@@ -171,7 +188,7 @@ export class TimePicker extends LitElement {
           { valueMissing: true },
           'This field is required.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
         return;
       }
       // validate min
@@ -197,14 +214,14 @@ export class TimePicker extends LitElement {
           { rangeUnderflow: true },
           'Please enter valid time within the min range.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       }
     } else {
       this.internals.setValidity(
         { patternMismatch: true },
         'Please enter valid min time.'
       );
-      this.invalidText = this.internals.validationMessage;
+      this.internalValidationMsg = this.internals.validationMessage;
     }
   }
 
@@ -220,14 +237,14 @@ export class TimePicker extends LitElement {
           { rangeOverflow: true },
           'Please enter valid time within the max range.'
         );
-        this.invalidText = this.internals.validationMessage;
+        this.internalValidationMsg = this.internals.validationMessage;
       }
     } else {
       this.internals.setValidity(
         { patternMismatch: true },
         'Please enter valid max time.'
       );
-      this.invalidText = this.internals.validationMessage;
+      this.internalValidationMsg = this.internals.validationMessage;
     }
   }
 

--- a/src/components/reusable/timepicker/timepicker.ts
+++ b/src/components/reusable/timepicker/timepicker.ts
@@ -149,7 +149,11 @@ export class TimePicker extends LitElement {
           ? html` <div class="caption">${this.caption}</div> `
           : null}
         ${this.isInvalid
-          ? html` <div class="error">${this.invalidText || this.internalValidationMsg}</div> `
+          ? html`
+              <div class="error">
+                ${this.invalidText || this.internalValidationMsg}
+              </div>
+            `
           : null}
         ${this.warnText !== '' && !this.isInvalid
           ? html`<div class="warn">${this.warnText}</div>`
@@ -171,8 +175,16 @@ export class TimePicker extends LitElement {
   }
 
   override updated(changedProps: any) {
-    //check if any (internal / external )error msg. present then isInvalid is true
-    this.isInvalid = this.invalidText !== '' || this.internalValidationMsg !== '' ? true : false;
+    if (
+      changedProps.has('invalidText') ||
+      changedProps.has('internalValidationMsg')
+    ) {
+      //check if any (internal / external )error msg. present then isInvalid is true
+      this.isInvalid =
+        this.invalidText !== '' || this.internalValidationMsg !== ''
+          ? true
+          : false;
+    }
     if (changedProps.has('value')) {
       this.inputEl.value = this.value;
       //set form data value


### PR DESCRIPTION
## Summary

1. Changed validation message property set to internal so that consumer can provide their own validation message via **invalidText** prop.

## ADO Link

https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/1322887/