### PR TITLE
fix(dropdown): remove height when closed

### DIFF
--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -130,12 +130,14 @@
   transition: transform 150ms ease-out, opacity 150ms ease-out,
     outline-color 150ms ease-out;
   visibility: hidden;
+  height: 0;
   transform: translateY(-10px);
   opacity: 0;
   z-index: -1;
 
   &.open {
     visibility: visible;
+    height: auto;
     transform: translateY(0);
     opacity: 1;
     z-index: 2;


### PR DESCRIPTION
## Summary

Dropdown options were taking up space on the page when hidden due to CSS visibility. Set height to 0 to prevent this.