### PR TITLE
fix(dropdown-option): mac chrome visibility issue

### DIFF
--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -131,14 +131,12 @@
   transition: transform 150ms ease-out, opacity 150ms ease-out,
     outline-color 150ms ease-out;
   visibility: hidden;
-  height: 0;
   transform: translateY(-10px);
   opacity: 0;
   z-index: -1;
 
   &.open {
     visibility: visible;
-    height: auto;
     transform: translateY(0);
     opacity: 1;
     z-index: 2;

--- a/src/components/reusable/dropdown/dropdownOption.scss
+++ b/src/components/reusable/dropdown/dropdownOption.scss
@@ -1,15 +1,12 @@
 @use '../../../common/scss/global.scss';
 
 :host {
-  display: inline-block;
+  display: block;
 }
 
 li {
   cursor: default;
   padding: 12px 16px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   transition: background-color 150ms ease-out;
 
   &[selected] {
@@ -30,6 +27,13 @@ li {
     &:hover {
       background-color: transparent;
     }
+  }
+
+  span {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 


### PR DESCRIPTION
## Summary

Hopefully resolves #37 @guptaashray

The issue seemed to be the .options height changing, which is unnecessary with visibility property.

I still could not reproduce the initial selection text not showing, or the multi-select tags text not showing.