### PR TITLE
fix(modal): add discrete transitions for supported browsers

### DIFF
--- a/src/components/reusable/modal/modal.scss
+++ b/src/components/reusable/modal/modal.scss
@@ -17,11 +17,11 @@ dialog {
   max-height: calc(100% - 32px);
 
   &[open] {
-    animation: dialog-in 250ms ease-out forwards;
+    animation: dialog-in 400ms ease-out;
   }
 
   &::backdrop {
-    background: none;
+    background-color: rgba(0, 0, 0, 0.4);
   }
 
   &.size--md {
@@ -30,6 +30,44 @@ dialog {
 
   &.size--lg {
     width: 711px;
+  }
+}
+
+@supports (transition-behavior: allow-discrete) {
+  dialog {
+    transition: opacity 400ms ease-out, transform 400ms ease-out,
+      overlay 400ms ease-out allow-discrete,
+      display 400ms ease-out allow-discrete;
+    opacity: 0;
+    transform: scale(0);
+
+    &::backdrop {
+      background-color: rgba(0, 0, 0, 0);
+      transition: display 400ms allow-discrete, overlay 400ms allow-discrete,
+        background-color 400ms;
+    }
+
+    &[open] {
+      animation: none;
+      opacity: 1;
+      transform: scale(1);
+
+      &::backdrop {
+        background-color: rgba(0, 0, 0, 0.4);
+      }
+    }
+  }
+}
+
+@keyframes dialog-in {
+  0% {
+    opacity: 0;
+    transform: scale(0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 
@@ -109,23 +147,4 @@ h1 {
   display: flex;
   align-items: center;
   gap: 16px;
-}
-
-@keyframes dialog-in {
-  0% {
-    opacity: 0;
-    transform: scale(0);
-    box-shadow: 0 0 0 100vmax rgba(0, 0, 0, 0);
-  }
-
-  75% {
-    transform: scale(1.1);
-    box-shadow: 0 0 0 100vmax rgba(0, 0, 0, 0.4);
-  }
-
-  100% {
-    opacity: 1;
-    transform: scale(1);
-    box-shadow: 0 0 0 100vmax rgba(0, 0, 0, 0.4);
-  }
 }

--- a/src/components/reusable/modal/modal.ts
+++ b/src/components/reusable/modal/modal.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, css } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import ModalScss from './modal.scss';
@@ -16,7 +16,25 @@ import closeIcon from '@carbon/icons/es/close/32';
  */
 @customElement('kyn-modal')
 export class Modal extends LitElement {
-  static override styles = ModalScss;
+  static override styles = [
+    ModalScss,
+    css`
+      @supports (transition-behavior: allow-discrete) {
+        @starting-style {
+          dialog[open] {
+            opacity: 0;
+            transform: scale(0);
+          }
+        }
+
+        @starting-style {
+          dialog[open]::backdrop {
+            background-color: rgb(0, 0, 0, 0);
+          }
+        }
+      }
+    `,
+  ];
 
   /** Modal open state. */
   @property({ type: Boolean })


### PR DESCRIPTION
## Summary

- Browsers that don't support discrete transitions will animate in, but not animate out. 
- Browsers that do support it will get both. 
- Once a browser adds support, it will be automatic.
- Changed transition/animation duration to 400ms.