### PR TITLE
fix(style): Dialog height while drawer is closing

### DIFF
--- a/src/components/reusable/sideDrawer/sideDrawer.scss
+++ b/src/components/reusable/sideDrawer/sideDrawer.scss
@@ -17,7 +17,7 @@ dialog {
   top: 0;
   right: 0;
   left: auto;
-  height: 100vh;
+  min-height: 100vh;
 
   &:modal {
     max-height: 100vh;

--- a/src/components/reusable/sideDrawer/sideDrawer.scss
+++ b/src/components/reusable/sideDrawer/sideDrawer.scss
@@ -17,11 +17,8 @@ dialog {
   top: 0;
   right: 0;
   left: auto;
-  min-height: 100vh;
-
-  &:modal {
-    max-height: 100vh;
-  }
+  height: 100vh;
+  max-height:100vh;
 
   &[open] {
     display: flex;


### PR DESCRIPTION
## Summary

- While closing drawer it's height getting cut and then it's being closed

## Screenshots

- If you see carefully while closing drawer, firstly the height of drawer is reduced and then it's getting closed. I fixed by setting `min-height: 100vh`; to `dialog` style

https://github.com/kyndryl-design-system/shidoka-applications/assets/140634142/05c14d5b-63ae-4a63-ad7b-5a5da38f52af


