### PR TITLE
fix(checkbox): label use position relative, resolves #182

### DIFF
--- a/src/components/reusable/checkbox/checkbox.scss
+++ b/src/components/reusable/checkbox/checkbox.scss
@@ -9,6 +9,7 @@ label {
   display: inline-flex;
   align-items: center;
   width: 100%;
+  position: relative;
 
   &[disabled] {
     color: var(--kd-color-text-disabled);


### PR DESCRIPTION
## Summary

Add `position: relative` to the `label`, parent of `span class="sr-only"`. Prevents the entire page having a large scrollbar in Chromium browsers.

## ADO Story or GitHub Issue Link

Resolves #182 
