### PR TITLE
fix(table-setting): hide column checkbox and lock icon when scroll

### DIFF
--- a/src/components/reusable/table/story-helpers/column-setting.ts
+++ b/src/components/reusable/table/story-helpers/column-setting.ts
@@ -46,12 +46,14 @@ class StoryColumSetting extends LitElement {
     }
     .t-head {
       top: 72px;
+      z-index: 2;
     }
     .seperator-div {
       height: 8px;
       background: white;
       position: sticky;
       top: 64px;
+      z-index: 3; // hide column behind scroll
     }
   `;
 


### PR DESCRIPTION
## Summary
- Raised by Jaideep M V when we scroll the row then it overlaps the header and shows lock icon and checkbox. 
- Resolved by setting z-index  
