### PR TITLE
fix(Tooltip): on-tooltip-toggle emit event listeners

### DIFF
--- a/src/components/reusable/tooltip/tooltip.ts
+++ b/src/components/reusable/tooltip/tooltip.ts
@@ -276,7 +276,7 @@ export class Tooltip extends LitElement {
   }
 
   override updated(changedProps: any) {
-    if (changedProps.has('open') && changedProps.get('open') !== undefined) {
+    if (changedProps.has('_open') && changedProps.get('_open') !== undefined) {
       this._emitToggle();
     }
   }


### PR DESCRIPTION
## Summary

**RCA**
Event listeners were not getting emitted on-tooltip-toggle due to typo of text "open" which was used on updated() method to _emitToggle() based on conditional check.

**Solution**
Update the text "open" to "_open" which solves the emit toggle action.


## Screenshots

**Before Fix**

<img width="1409" alt="image" src="https://github.com/user-attachments/assets/a88107a0-90c9-45b4-a2af-b56ef6241a3b">



**After Fix**

<img width="1396" alt="image" src="https://github.com/user-attachments/assets/59886474-dc8c-4471-bf53-bc452eede4bf">
