### PR TITLE
fix(modal): close button accessibility label

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -667,7 +667,7 @@
           "type": {
             "text": "object"
           },
-          "default": "{\r\n  handle: 'kyn-widget-drag-handle', // set the drag handle\r\n  margin: 16, // 32px gap\r\n  animate: false, // disable animation until after initial load\r\n  columnOpts: {\r\n    breakpointForWindow: true, // break based on viewport size, not grid size\r\n    breakpoints: [\r\n      { w: 671, c: 4 }, // shidoka-foundation sm breakpoint, 4 column grid\r\n      { w: 1183, c: 8 }, // shidoka-foundation md breakpoint, 8 column grid\r\n    ],\r\n  },\r\n}"
+          "default": "{\n  handle: 'kyn-widget-drag-handle', // set the drag handle\n  margin: 16, // 32px gap\n  animate: false, // disable animation until after initial load\n  columnOpts: {\n    breakpointForWindow: true, // break based on viewport size, not grid size\n    breakpoints: [\n      { w: 671, c: 4 }, // shidoka-foundation sm breakpoint, 4 column grid\n      { w: 1183, c: 8 }, // shidoka-foundation md breakpoint, 8 column grid\n    ],\n  },\n}"
         },
         {
           "kind": "variable",
@@ -675,7 +675,7 @@
           "type": {
             "text": "object"
           },
-          "default": "{\r\n  pill: {\r\n    max: {\r\n      w: 2,\r\n      h: 2,\r\n    },\r\n    xl: {\r\n      w: 3,\r\n      h: 3,\r\n    },\r\n    lg: {\r\n      w: 3,\r\n      h: 3,\r\n    },\r\n    md: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n  standard: {\r\n    max: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n    xl: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n    lg: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n    md: {\r\n      w: 8,\r\n      h: 8,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n  standardShort: {\r\n    max: {\r\n      w: 4,\r\n      h: 2,\r\n    },\r\n    xl: {\r\n      w: 4,\r\n      h: 3,\r\n    },\r\n    lg: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n    md: {\r\n      w: 8,\r\n      h: 5,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n  wide: {\r\n    max: {\r\n      w: 6,\r\n      h: 4,\r\n    },\r\n    xl: {\r\n      w: 6,\r\n      h: 4,\r\n    },\r\n    lg: {\r\n      w: 6,\r\n      h: 4,\r\n    },\r\n    md: {\r\n      w: 8,\r\n      h: 8,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n  wideShort: {\r\n    max: {\r\n      w: 6,\r\n      h: 3,\r\n    },\r\n    xl: {\r\n      w: 6,\r\n      h: 4,\r\n    },\r\n    lg: {\r\n      w: 6,\r\n      h: 4,\r\n    },\r\n    md: {\r\n      w: 8,\r\n      h: 4,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n  xlWide: {\r\n    max: {\r\n      w: 8,\r\n      h: 4,\r\n    },\r\n    xl: {\r\n      w: 8,\r\n      h: 4,\r\n    },\r\n    lg: {\r\n      w: 8,\r\n      h: 4,\r\n    },\r\n    md: {\r\n      w: 8,\r\n      h: 8,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n  xlWideShort: {\r\n    max: {\r\n      w: 8,\r\n      h: 3,\r\n    },\r\n    xl: {\r\n      w: 8,\r\n      h: 4,\r\n    },\r\n    lg: {\r\n      w: 8,\r\n      h: 4,\r\n    },\r\n    md: {\r\n      w: 8,\r\n      h: 5,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n  xxlWide: {\r\n    max: {\r\n      w: 10,\r\n      h: 4,\r\n    },\r\n    xl: {\r\n      w: 10,\r\n      h: 4,\r\n    },\r\n    lg: {\r\n      w: 10,\r\n      h: 4,\r\n    },\r\n    md: {\r\n      w: 8,\r\n      h: 8,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n  xxlWideShort: {\r\n    max: {\r\n      w: 10,\r\n      h: 3,\r\n    },\r\n    xl: {\r\n      w: 10,\r\n      h: 4,\r\n    },\r\n    lg: {\r\n      w: 10,\r\n      h: 4,\r\n    },\r\n    md: {\r\n      w: 8,\r\n      h: 5,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n  xxxlWide: {\r\n    max: {\r\n      w: 12,\r\n      h: 4,\r\n    },\r\n    xl: {\r\n      w: 12,\r\n      h: 4,\r\n    },\r\n    lg: {\r\n      w: 12,\r\n      h: 4,\r\n    },\r\n    md: {\r\n      w: 8,\r\n      h: 8,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n  xxxlWideShort: {\r\n    max: {\r\n      w: 12,\r\n      h: 3,\r\n    },\r\n    xl: {\r\n      w: 12,\r\n      h: 3,\r\n    },\r\n    lg: {\r\n      w: 12,\r\n      h: 4,\r\n    },\r\n    md: {\r\n      w: 8,\r\n      h: 5,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n  tower: {\r\n    max: {\r\n      w: 12,\r\n      h: 7,\r\n    },\r\n    xl: {\r\n      w: 12,\r\n      h: 7,\r\n    },\r\n    lg: {\r\n      w: 12,\r\n      h: 7,\r\n    },\r\n    md: {\r\n      w: 8,\r\n      h: 8,\r\n    },\r\n    sm: {\r\n      w: 4,\r\n      h: 4,\r\n    },\r\n  },\r\n}"
+          "default": "{\n  pill: {\n    max: {\n      w: 2,\n      h: 2,\n    },\n    xl: {\n      w: 3,\n      h: 3,\n    },\n    lg: {\n      w: 3,\n      h: 3,\n    },\n    md: {\n      w: 4,\n      h: 4,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n  standard: {\n    max: {\n      w: 4,\n      h: 4,\n    },\n    xl: {\n      w: 4,\n      h: 4,\n    },\n    lg: {\n      w: 4,\n      h: 4,\n    },\n    md: {\n      w: 8,\n      h: 8,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n  standardShort: {\n    max: {\n      w: 4,\n      h: 2,\n    },\n    xl: {\n      w: 4,\n      h: 3,\n    },\n    lg: {\n      w: 4,\n      h: 4,\n    },\n    md: {\n      w: 8,\n      h: 5,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n  wide: {\n    max: {\n      w: 6,\n      h: 4,\n    },\n    xl: {\n      w: 6,\n      h: 4,\n    },\n    lg: {\n      w: 6,\n      h: 4,\n    },\n    md: {\n      w: 8,\n      h: 8,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n  wideShort: {\n    max: {\n      w: 6,\n      h: 3,\n    },\n    xl: {\n      w: 6,\n      h: 4,\n    },\n    lg: {\n      w: 6,\n      h: 4,\n    },\n    md: {\n      w: 8,\n      h: 4,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n  xlWide: {\n    max: {\n      w: 8,\n      h: 4,\n    },\n    xl: {\n      w: 8,\n      h: 4,\n    },\n    lg: {\n      w: 8,\n      h: 4,\n    },\n    md: {\n      w: 8,\n      h: 8,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n  xlWideShort: {\n    max: {\n      w: 8,\n      h: 3,\n    },\n    xl: {\n      w: 8,\n      h: 4,\n    },\n    lg: {\n      w: 8,\n      h: 4,\n    },\n    md: {\n      w: 8,\n      h: 5,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n  xxlWide: {\n    max: {\n      w: 10,\n      h: 4,\n    },\n    xl: {\n      w: 10,\n      h: 4,\n    },\n    lg: {\n      w: 10,\n      h: 4,\n    },\n    md: {\n      w: 8,\n      h: 8,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n  xxlWideShort: {\n    max: {\n      w: 10,\n      h: 3,\n    },\n    xl: {\n      w: 10,\n      h: 4,\n    },\n    lg: {\n      w: 10,\n      h: 4,\n    },\n    md: {\n      w: 8,\n      h: 5,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n  xxxlWide: {\n    max: {\n      w: 12,\n      h: 4,\n    },\n    xl: {\n      w: 12,\n      h: 4,\n    },\n    lg: {\n      w: 12,\n      h: 4,\n    },\n    md: {\n      w: 8,\n      h: 8,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n  xxxlWideShort: {\n    max: {\n      w: 12,\n      h: 3,\n    },\n    xl: {\n      w: 12,\n      h: 3,\n    },\n    lg: {\n      w: 12,\n      h: 4,\n    },\n    md: {\n      w: 8,\n      h: 5,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n  tower: {\n    max: {\n      w: 12,\n      h: 7,\n    },\n    xl: {\n      w: 12,\n      h: 7,\n    },\n    lg: {\n      w: 12,\n      h: 7,\n    },\n    md: {\n      w: 8,\n      h: 8,\n    },\n    sm: {\n      w: 4,\n      h: 4,\n    },\n  },\n}"
         },
         {
           "kind": "variable",
@@ -683,7 +683,7 @@
           "type": {
             "text": "object"
           },
-          "default": "{\r\n  default: {\r\n    max: {\r\n      minW: WidgetSizes.pill.max.w,\r\n      minH: WidgetSizes.pill.max.h,\r\n    },\r\n    xl: {\r\n      minW: WidgetSizes.pill.xl.w,\r\n      minH: WidgetSizes.pill.xl.h,\r\n    },\r\n    lg: {\r\n      minW: WidgetSizes.pill.lg.w,\r\n      minH: WidgetSizes.pill.lg.h,\r\n    },\r\n    md: {\r\n      minW: WidgetSizes.pill.md.w,\r\n      minH: WidgetSizes.pill.md.h,\r\n    },\r\n    sm: {\r\n      minW: WidgetSizes.pill.sm.w,\r\n      minH: WidgetSizes.pill.sm.h,\r\n    },\r\n  },\r\n  table: {\r\n    max: {\r\n      minW: WidgetSizes.wide.max.w,\r\n      minH: WidgetSizes.wide.max.h,\r\n    },\r\n    xl: {\r\n      minW: WidgetSizes.wide.xl.w,\r\n      minH: WidgetSizes.wide.xl.h,\r\n    },\r\n    lg: {\r\n      minW: WidgetSizes.wide.lg.w,\r\n      minH: WidgetSizes.wide.lg.h,\r\n    },\r\n    md: {\r\n      minW: WidgetSizes.wide.md.w,\r\n      minH: WidgetSizes.wide.md.h,\r\n    },\r\n    sm: {\r\n      minW: WidgetSizes.wide.sm.w,\r\n      minH: WidgetSizes.wide.sm.h,\r\n    },\r\n  },\r\n  chart: {\r\n    max: {\r\n      minW: WidgetSizes.wide.max.w,\r\n      minH: WidgetSizes.wide.max.h,\r\n    },\r\n    xl: {\r\n      minW: WidgetSizes.wide.xl.w,\r\n      minH: WidgetSizes.wide.xl.h,\r\n    },\r\n    lg: {\r\n      minW: WidgetSizes.wide.lg.w,\r\n      minH: WidgetSizes.wide.lg.h,\r\n    },\r\n    md: {\r\n      minW: WidgetSizes.wide.md.w,\r\n      minH: WidgetSizes.wide.md.h,\r\n    },\r\n    sm: {\r\n      minW: WidgetSizes.wide.sm.w,\r\n      minH: WidgetSizes.wide.sm.h,\r\n    },\r\n  },\r\n  list: {\r\n    max: {\r\n      minW: WidgetSizes.standard.max.w,\r\n      minH: WidgetSizes.standard.max.h,\r\n    },\r\n    xl: {\r\n      minW: WidgetSizes.standard.xl.w,\r\n      minH: WidgetSizes.standard.xl.h,\r\n    },\r\n    lg: {\r\n      minW: WidgetSizes.standard.lg.w,\r\n      minH: WidgetSizes.standard.lg.h,\r\n    },\r\n    md: {\r\n      minW: WidgetSizes.standard.md.w,\r\n      minH: WidgetSizes.standard.md.h,\r\n    },\r\n    sm: {\r\n      minW: WidgetSizes.standard.sm.w,\r\n      minH: WidgetSizes.standard.sm.h,\r\n    },\r\n  },\r\n  content: {\r\n    max: {\r\n      minW: WidgetSizes.standard.max.w,\r\n      minH: WidgetSizes.standard.max.h,\r\n    },\r\n    xl: {\r\n      minW: WidgetSizes.standard.xl.w,\r\n      minH: WidgetSizes.standard.xl.h,\r\n    },\r\n    lg: {\r\n      minW: WidgetSizes.standard.lg.w,\r\n      minH: WidgetSizes.standard.lg.h,\r\n    },\r\n    md: {\r\n      minW: WidgetSizes.standard.md.w,\r\n      minH: WidgetSizes.standard.md.h,\r\n    },\r\n    sm: {\r\n      minW: WidgetSizes.standard.sm.w,\r\n      minH: WidgetSizes.standard.sm.h,\r\n    },\r\n  },\r\n  alert: {\r\n    max: {\r\n      minW: WidgetSizes.standard.max.w,\r\n      minH: WidgetSizes.standard.max.h,\r\n    },\r\n    xl: {\r\n      minW: WidgetSizes.standard.xl.w,\r\n      minH: WidgetSizes.standard.xl.h,\r\n    },\r\n    lg: {\r\n      minW: WidgetSizes.standard.lg.w,\r\n      minH: WidgetSizes.standard.lg.h,\r\n    },\r\n    md: {\r\n      minW: WidgetSizes.standard.md.w,\r\n      minH: WidgetSizes.standard.md.h,\r\n    },\r\n    sm: {\r\n      minW: WidgetSizes.standard.sm.w,\r\n      minH: WidgetSizes.standard.sm.h,\r\n    },\r\n  },\r\n  cards: {\r\n    max: {\r\n      minW: WidgetSizes.wide.max.w,\r\n      minH: WidgetSizes.wide.max.h,\r\n    },\r\n    xl: {\r\n      minW: WidgetSizes.wide.xl.w,\r\n      minH: WidgetSizes.wide.xl.h,\r\n    },\r\n    lg: {\r\n      minW: WidgetSizes.wide.lg.w,\r\n      minH: WidgetSizes.wide.lg.h,\r\n    },\r\n    md: {\r\n      minW: WidgetSizes.wide.md.w,\r\n      minH: WidgetSizes.wide.md.h,\r\n    },\r\n    sm: {\r\n      minW: WidgetSizes.wide.sm.w,\r\n      minH: WidgetSizes.wide.sm.h,\r\n    },\r\n  },\r\n  accordion: {\r\n    max: {\r\n      minW: WidgetSizes.standard.max.w,\r\n      minH: WidgetSizes.standard.max.h,\r\n    },\r\n    xl: {\r\n      minW: WidgetSizes.standard.xl.w,\r\n      minH: WidgetSizes.standard.xl.h,\r\n    },\r\n    lg: {\r\n      minW: WidgetSizes.standard.lg.w,\r\n      minH: WidgetSizes.standard.lg.h,\r\n    },\r\n    md: {\r\n      minW: WidgetSizes.standard.md.w,\r\n      minH: WidgetSizes.standard.md.h,\r\n    },\r\n    sm: {\r\n      minW: WidgetSizes.standard.sm.w,\r\n      minH: WidgetSizes.standard.sm.h,\r\n    },\r\n  },\r\n}"
+          "default": "{\n  default: {\n    max: {\n      minW: WidgetSizes.pill.max.w,\n      minH: WidgetSizes.pill.max.h,\n    },\n    xl: {\n      minW: WidgetSizes.pill.xl.w,\n      minH: WidgetSizes.pill.xl.h,\n    },\n    lg: {\n      minW: WidgetSizes.pill.lg.w,\n      minH: WidgetSizes.pill.lg.h,\n    },\n    md: {\n      minW: WidgetSizes.pill.md.w,\n      minH: WidgetSizes.pill.md.h,\n    },\n    sm: {\n      minW: WidgetSizes.pill.sm.w,\n      minH: WidgetSizes.pill.sm.h,\n    },\n  },\n  table: {\n    max: {\n      minW: WidgetSizes.wide.max.w,\n      minH: WidgetSizes.wide.max.h,\n    },\n    xl: {\n      minW: WidgetSizes.wide.xl.w,\n      minH: WidgetSizes.wide.xl.h,\n    },\n    lg: {\n      minW: WidgetSizes.wide.lg.w,\n      minH: WidgetSizes.wide.lg.h,\n    },\n    md: {\n      minW: WidgetSizes.wide.md.w,\n      minH: WidgetSizes.wide.md.h,\n    },\n    sm: {\n      minW: WidgetSizes.wide.sm.w,\n      minH: WidgetSizes.wide.sm.h,\n    },\n  },\n  chart: {\n    max: {\n      minW: WidgetSizes.wide.max.w,\n      minH: WidgetSizes.wide.max.h,\n    },\n    xl: {\n      minW: WidgetSizes.wide.xl.w,\n      minH: WidgetSizes.wide.xl.h,\n    },\n    lg: {\n      minW: WidgetSizes.wide.lg.w,\n      minH: WidgetSizes.wide.lg.h,\n    },\n    md: {\n      minW: WidgetSizes.wide.md.w,\n      minH: WidgetSizes.wide.md.h,\n    },\n    sm: {\n      minW: WidgetSizes.wide.sm.w,\n      minH: WidgetSizes.wide.sm.h,\n    },\n  },\n  list: {\n    max: {\n      minW: WidgetSizes.standard.max.w,\n      minH: WidgetSizes.standard.max.h,\n    },\n    xl: {\n      minW: WidgetSizes.standard.xl.w,\n      minH: WidgetSizes.standard.xl.h,\n    },\n    lg: {\n      minW: WidgetSizes.standard.lg.w,\n      minH: WidgetSizes.standard.lg.h,\n    },\n    md: {\n      minW: WidgetSizes.standard.md.w,\n      minH: WidgetSizes.standard.md.h,\n    },\n    sm: {\n      minW: WidgetSizes.standard.sm.w,\n      minH: WidgetSizes.standard.sm.h,\n    },\n  },\n  content: {\n    max: {\n      minW: WidgetSizes.standard.max.w,\n      minH: WidgetSizes.standard.max.h,\n    },\n    xl: {\n      minW: WidgetSizes.standard.xl.w,\n      minH: WidgetSizes.standard.xl.h,\n    },\n    lg: {\n      minW: WidgetSizes.standard.lg.w,\n      minH: WidgetSizes.standard.lg.h,\n    },\n    md: {\n      minW: WidgetSizes.standard.md.w,\n      minH: WidgetSizes.standard.md.h,\n    },\n    sm: {\n      minW: WidgetSizes.standard.sm.w,\n      minH: WidgetSizes.standard.sm.h,\n    },\n  },\n  alert: {\n    max: {\n      minW: WidgetSizes.standard.max.w,\n      minH: WidgetSizes.standard.max.h,\n    },\n    xl: {\n      minW: WidgetSizes.standard.xl.w,\n      minH: WidgetSizes.standard.xl.h,\n    },\n    lg: {\n      minW: WidgetSizes.standard.lg.w,\n      minH: WidgetSizes.standard.lg.h,\n    },\n    md: {\n      minW: WidgetSizes.standard.md.w,\n      minH: WidgetSizes.standard.md.h,\n    },\n    sm: {\n      minW: WidgetSizes.standard.sm.w,\n      minH: WidgetSizes.standard.sm.h,\n    },\n  },\n  cards: {\n    max: {\n      minW: WidgetSizes.wide.max.w,\n      minH: WidgetSizes.wide.max.h,\n    },\n    xl: {\n      minW: WidgetSizes.wide.xl.w,\n      minH: WidgetSizes.wide.xl.h,\n    },\n    lg: {\n      minW: WidgetSizes.wide.lg.w,\n      minH: WidgetSizes.wide.lg.h,\n    },\n    md: {\n      minW: WidgetSizes.wide.md.w,\n      minH: WidgetSizes.wide.md.h,\n    },\n    sm: {\n      minW: WidgetSizes.wide.sm.w,\n      minH: WidgetSizes.wide.sm.h,\n    },\n  },\n  accordion: {\n    max: {\n      minW: WidgetSizes.standard.max.w,\n      minH: WidgetSizes.standard.max.h,\n    },\n    xl: {\n      minW: WidgetSizes.standard.xl.w,\n      minH: WidgetSizes.standard.xl.h,\n    },\n    lg: {\n      minW: WidgetSizes.standard.lg.w,\n      minH: WidgetSizes.standard.lg.h,\n    },\n    md: {\n      minW: WidgetSizes.standard.md.w,\n      minH: WidgetSizes.standard.md.h,\n    },\n    sm: {\n      minW: WidgetSizes.standard.sm.w,\n      minH: WidgetSizes.standard.sm.h,\n    },\n  },\n}"
         }
       ],
       "exports": [
@@ -758,7 +758,7 @@
               "description": " imported enums object"
             }
           ],
-          "description": "Convert an object to an array of only its values.\r\nUsed when importing enums in component stories for populating argType dropdowns."
+          "description": "Convert an object to an array of only its values.\nUsed when importing enums in component stories for populating argType dropdowns."
         }
       ],
       "exports": [
@@ -841,6 +841,20 @@
             },
             {
               "kind": "field",
+              "name": "_handleInvalid",
+              "type": {
+                "text": "Function"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_handleFormdata",
+              "type": {
+                "text": "Function"
+              }
+            },
+            {
+              "kind": "field",
               "name": "_onUpdated",
               "type": {
                 "text": "Function"
@@ -896,12 +910,6 @@
               "default": "''",
               "description": "Input invalid text.",
               "attribute": "invalidText"
-            },
-            {
-              "kind": "method",
-              "name": "_handleInvalid",
-              "privacy": "private",
-              "description": "Handles the invalid event, triggered on form submit, and runs validation."
             },
             {
               "kind": "method",
@@ -1416,6 +1424,531 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/global/localNav/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LocalNav",
+          "declaration": {
+            "name": "LocalNav",
+            "module": "./localNav"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "LocalNavLink",
+          "declaration": {
+            "name": "LocalNavLink",
+            "module": "./localNavLink"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/global/localNav/localNav.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "The global Side Navigation component.",
+          "name": "LocalNav",
+          "slots": [
+            {
+              "description": "The default slot, for local nav links.",
+              "name": "unnamed"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "pinned",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Local nav pinned state.",
+              "attribute": "pinned"
+            },
+            {
+              "kind": "field",
+              "name": "pinText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Pin'",
+              "description": "Pin open button assistive text.",
+              "attribute": "pinText"
+            },
+            {
+              "kind": "field",
+              "name": "unpinText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Unpin'",
+              "description": "Unpin button assistive text.",
+              "attribute": "unpinText"
+            },
+            {
+              "kind": "field",
+              "name": "textStrings",
+              "type": {
+                "text": "object"
+              },
+              "default": "{\n    toggleMenu: 'Toggle Menu',\n    collapse: 'Collapse',\n    menu: 'Menu',\n  }",
+              "description": "Menu toggle button assistive text.",
+              "attribute": "textStrings"
+            },
+            {
+              "kind": "method",
+              "name": "_handleNavToggle",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_handleMobileNavToggle",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "handlePointerEnter",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "PointerEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "handlePointerLeave",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "PointerEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_updateChildren",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "handleSlotChange",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "_handleLinkActive",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "any"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_handleClickOut",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            }
+          ],
+          "events": [
+            {
+              "description": "Captures the click event and emits the open state and original event details.",
+              "name": "on-toggle"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "pinned",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Local nav pinned state.",
+              "fieldName": "pinned"
+            },
+            {
+              "name": "pinText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Pin'",
+              "description": "Pin open button assistive text.",
+              "fieldName": "pinText"
+            },
+            {
+              "name": "unpinText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Unpin'",
+              "description": "Unpin button assistive text.",
+              "fieldName": "unpinText"
+            },
+            {
+              "name": "textStrings",
+              "type": {
+                "text": "object"
+              },
+              "default": "{\n    toggleMenu: 'Toggle Menu',\n    collapse: 'Collapse',\n    menu: 'Menu',\n  }",
+              "description": "Menu toggle button assistive text.",
+              "fieldName": "textStrings"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kyn-local-nav",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LocalNav",
+          "declaration": {
+            "name": "LocalNav",
+            "module": "src/components/global/localNav/localNav.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kyn-local-nav",
+          "declaration": {
+            "name": "LocalNav",
+            "module": "src/components/global/localNav/localNav.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/global/localNav/localNavLink.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Link component for use in the global Side Navigation component.",
+          "name": "LocalNavLink",
+          "slots": [
+            {
+              "description": "The default slot, for the link text.",
+              "name": "unnamed"
+            },
+            {
+              "description": "Slot for an icon. Use 16px size.",
+              "name": "icon"
+            },
+            {
+              "description": "Slot for the next level of links, supports three levels.",
+              "name": "links"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "href",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Link url.",
+              "attribute": "href"
+            },
+            {
+              "kind": "field",
+              "name": "_expanded",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Expanded state."
+            },
+            {
+              "kind": "field",
+              "name": "active",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Active state.",
+              "attribute": "active",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Disabled state.",
+              "attribute": "disabled"
+            },
+            {
+              "kind": "field",
+              "name": "backText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Back'",
+              "description": "Text for mobile \"Back\" button.",
+              "attribute": "backText"
+            },
+            {
+              "kind": "method",
+              "name": "_handleTextSlotChange",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "_getSlotText",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "_handleLinksSlotChange",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "updateChildren",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "determineLevel",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "handlePointerEnter",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "PointerEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "handlePointerLeave",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "PointerEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_positionMenu",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "_handleBack",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "handleClick",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_handleClickOut",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            }
+          ],
+          "events": [
+            {
+              "description": "Captures the click event and emits the original event, level, and if default was prevented.",
+              "name": "on-click"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "href",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Link url.",
+              "fieldName": "href"
+            },
+            {
+              "name": "active",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Active state.",
+              "fieldName": "active"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Disabled state.",
+              "fieldName": "disabled"
+            },
+            {
+              "name": "backText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Back'",
+              "description": "Text for mobile \"Back\" button.",
+              "fieldName": "backText"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kyn-local-nav-link",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LocalNavLink",
+          "declaration": {
+            "name": "LocalNavLink",
+            "module": "src/components/global/localNav/localNavLink.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kyn-local-nav-link",
+          "declaration": {
+            "name": "LocalNavLink",
+            "module": "src/components/global/localNav/localNavLink.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/global/uiShell/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "UiShell",
+          "declaration": {
+            "name": "UiShell",
+            "module": "./uiShell"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/global/uiShell/uiShell.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Container to help with positioning and padding of the global elements such as: adds padding for the fixed Header and Local Nav, adds main content gutters, and makes Footer sticky. This takes the onus off of the consuming app to configure these values.",
+          "name": "UiShell",
+          "slots": [
+            {
+              "description": "Slot for global elements.",
+              "name": "unnamed"
+            }
+          ],
+          "members": [
+            {
+              "kind": "method",
+              "name": "handleSlotChange",
+              "privacy": "private"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kyn-ui-shell",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "UiShell",
+          "declaration": {
+            "name": "UiShell",
+            "module": "src/components/global/uiShell/uiShell.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kyn-ui-shell",
+          "declaration": {
+            "name": "UiShell",
+            "module": "src/components/global/uiShell/uiShell.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/global/header/header.ts",
       "declarations": [
         {
@@ -1807,7 +2340,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "DEPRECATED. Use `label` instead.\r\nButton assistive text, title + aria-label.",
+              "description": "DEPRECATED. Use `label` instead.\nButton assistive text, title + aria-label.",
               "attribute": "assistiveText"
             },
             {
@@ -1920,7 +2453,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "DEPRECATED. Use `label` instead.\r\nButton assistive text, title + aria-label.",
+              "description": "DEPRECATED. Use `label` instead.\nButton assistive text, title + aria-label.",
               "fieldName": "assistiveText"
             },
             {
@@ -3115,531 +3648,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/global/localNav/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "LocalNav",
-          "declaration": {
-            "name": "LocalNav",
-            "module": "./localNav"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "LocalNavLink",
-          "declaration": {
-            "name": "LocalNavLink",
-            "module": "./localNavLink"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/global/localNav/localNav.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "The global Side Navigation component.",
-          "name": "LocalNav",
-          "slots": [
-            {
-              "description": "The default slot, for local nav links.",
-              "name": "unnamed"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "pinned",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Local nav pinned state.",
-              "attribute": "pinned"
-            },
-            {
-              "kind": "field",
-              "name": "pinText",
-              "type": {
-                "text": "string"
-              },
-              "default": "'Pin'",
-              "description": "Pin open button assistive text.",
-              "attribute": "pinText"
-            },
-            {
-              "kind": "field",
-              "name": "unpinText",
-              "type": {
-                "text": "string"
-              },
-              "default": "'Unpin'",
-              "description": "Unpin button assistive text.",
-              "attribute": "unpinText"
-            },
-            {
-              "kind": "field",
-              "name": "textStrings",
-              "type": {
-                "text": "object"
-              },
-              "default": "{\r\n    toggleMenu: 'Toggle Menu',\r\n    collapse: 'Collapse',\r\n    menu: 'Menu',\r\n  }",
-              "description": "Menu toggle button assistive text.",
-              "attribute": "textStrings"
-            },
-            {
-              "kind": "method",
-              "name": "_handleNavToggle",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_handleMobileNavToggle",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "handlePointerEnter",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "PointerEvent"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "handlePointerLeave",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "PointerEvent"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_updateChildren",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "handleSlotChange",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "_handleLinkActive",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "any"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_handleClickOut",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            }
-          ],
-          "events": [
-            {
-              "description": "Captures the click event and emits the open state and original event details.",
-              "name": "on-toggle"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "pinned",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Local nav pinned state.",
-              "fieldName": "pinned"
-            },
-            {
-              "name": "pinText",
-              "type": {
-                "text": "string"
-              },
-              "default": "'Pin'",
-              "description": "Pin open button assistive text.",
-              "fieldName": "pinText"
-            },
-            {
-              "name": "unpinText",
-              "type": {
-                "text": "string"
-              },
-              "default": "'Unpin'",
-              "description": "Unpin button assistive text.",
-              "fieldName": "unpinText"
-            },
-            {
-              "name": "textStrings",
-              "type": {
-                "text": "object"
-              },
-              "default": "{\r\n    toggleMenu: 'Toggle Menu',\r\n    collapse: 'Collapse',\r\n    menu: 'Menu',\r\n  }",
-              "description": "Menu toggle button assistive text.",
-              "fieldName": "textStrings"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "kyn-local-nav",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "LocalNav",
-          "declaration": {
-            "name": "LocalNav",
-            "module": "src/components/global/localNav/localNav.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "kyn-local-nav",
-          "declaration": {
-            "name": "LocalNav",
-            "module": "src/components/global/localNav/localNav.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/global/localNav/localNavLink.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "Link component for use in the global Side Navigation component.",
-          "name": "LocalNavLink",
-          "slots": [
-            {
-              "description": "The default slot, for the link text.",
-              "name": "unnamed"
-            },
-            {
-              "description": "Slot for an icon. Use 16px size.",
-              "name": "icon"
-            },
-            {
-              "description": "Slot for the next level of links, supports three levels.",
-              "name": "links"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "href",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Link url.",
-              "attribute": "href"
-            },
-            {
-              "kind": "field",
-              "name": "_expanded",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Expanded state."
-            },
-            {
-              "kind": "field",
-              "name": "active",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Active state.",
-              "attribute": "active",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Disabled state.",
-              "attribute": "disabled"
-            },
-            {
-              "kind": "field",
-              "name": "backText",
-              "type": {
-                "text": "string"
-              },
-              "default": "'Back'",
-              "description": "Text for mobile \"Back\" button.",
-              "attribute": "backText"
-            },
-            {
-              "kind": "method",
-              "name": "_handleTextSlotChange",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "_getSlotText",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "_handleLinksSlotChange",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "updateChildren",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "determineLevel",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "handlePointerEnter",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "PointerEvent"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "handlePointerLeave",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "PointerEvent"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_positionMenu",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "_handleBack",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "handleClick",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_handleClickOut",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            }
-          ],
-          "events": [
-            {
-              "description": "Captures the click event and emits the original event, level, and if default was prevented.",
-              "name": "on-click"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "href",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Link url.",
-              "fieldName": "href"
-            },
-            {
-              "name": "active",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Active state.",
-              "fieldName": "active"
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Disabled state.",
-              "fieldName": "disabled"
-            },
-            {
-              "name": "backText",
-              "type": {
-                "text": "string"
-              },
-              "default": "'Back'",
-              "description": "Text for mobile \"Back\" button.",
-              "fieldName": "backText"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "kyn-local-nav-link",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "LocalNavLink",
-          "declaration": {
-            "name": "LocalNavLink",
-            "module": "src/components/global/localNav/localNavLink.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "kyn-local-nav-link",
-          "declaration": {
-            "name": "LocalNavLink",
-            "module": "src/components/global/localNav/localNavLink.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/global/uiShell/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "UiShell",
-          "declaration": {
-            "name": "UiShell",
-            "module": "./uiShell"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/global/uiShell/uiShell.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "Container to help with positioning and padding of the global elements such as: adds padding for the fixed Header and Local Nav, adds main content gutters, and makes Footer sticky. This takes the onus off of the consuming app to configure these values.",
-          "name": "UiShell",
-          "slots": [
-            {
-              "description": "Slot for global elements.",
-              "name": "unnamed"
-            }
-          ],
-          "members": [
-            {
-              "kind": "method",
-              "name": "handleSlotChange",
-              "privacy": "private"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "kyn-ui-shell",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "UiShell",
-          "declaration": {
-            "name": "UiShell",
-            "module": "src/components/global/uiShell/uiShell.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "kyn-ui-shell",
-          "declaration": {
-            "name": "UiShell",
-            "module": "src/components/global/uiShell/uiShell.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/components/reusable/breadcrumbs/breadcrumbItem.ts",
       "declarations": [
         {
@@ -3862,7 +3870,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "DEPRECATED. `kyn-card` Web Component.\r\nThis is deprecated and moved to Foundation.",
+          "description": "DEPRECATED. `kyn-card` Web Component.\nThis is deprecated and moved to Foundation.",
           "name": "Card",
           "slots": [
             {
@@ -4072,7 +4080,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Determines whether the label should be hidden from visual view but remain accessible\r\nto screen readers for accessibility purposes.",
+              "description": "Determines whether the label should be hidden from visual view but remain accessible\nto screen readers for accessibility purposes.",
               "attribute": "visiblyHidden"
             },
             {
@@ -4130,7 +4138,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Determines whether the label should be hidden from visual view but remain accessible\r\nto screen readers for accessibility purposes.",
+              "description": "Determines whether the label should be hidden from visual view but remain accessible\nto screen readers for accessibility purposes.",
               "fieldName": "visiblyHidden"
             },
             {
@@ -4276,7 +4284,7 @@
             {
               "kind": "field",
               "name": "textStrings",
-              "default": "{\r\n  selectAll: 'Select all',\r\n  showMore: 'Show more',\r\n  showLess: 'Show less',\r\n  search: 'Search',\r\n  required: 'Required',\r\n  error: 'Error',\r\n}",
+              "default": "{\n  selectAll: 'Select all',\n  showMore: 'Show more',\n  showLess: 'Show less',\n  search: 'Search',\n  required: 'Required',\n  error: 'Error',\n}",
               "description": "Text string customization.",
               "attribute": "textStrings",
               "type": {
@@ -4418,16 +4426,6 @@
               "default": "''",
               "description": "Input invalid text.",
               "attribute": "invalidText",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_handleInvalid",
-              "privacy": "private",
-              "description": "Handles the invalid event, triggered on form submit, and runs validation.",
               "inheritedFrom": {
                 "name": "FormMixin",
                 "module": "src/common/mixins/form-input.ts"
@@ -4869,7 +4867,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Specifies the granularity that the value must adhere to, or the special value any,\r\nFor date inputs, the value of step is given in days; and is treated as a number of milliseconds equal to 86,400,000 times the step value.\r\nThe default value of step is 1, indicating 1 day.",
+              "description": "Specifies the granularity that the value must adhere to, or the special value any,\nFor date inputs, the value of step is given in days; and is treated as a number of milliseconds equal to 86,400,000 times the step value.\nThe default value of step is 1, indicating 1 day.",
               "attribute": "step"
             },
             {
@@ -4977,16 +4975,6 @@
               "default": "''",
               "description": "Input invalid text.",
               "attribute": "invalidText",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_handleInvalid",
-              "privacy": "private",
-              "description": "Handles the invalid event, triggered on form submit, and runs validation.",
               "inheritedFrom": {
                 "name": "FormMixin",
                 "module": "src/common/mixins/form-input.ts"
@@ -5143,7 +5131,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Specifies the granularity that the value must adhere to, or the special value any,\r\nFor date inputs, the value of step is given in days; and is treated as a number of milliseconds equal to 86,400,000 times the step value.\r\nThe default value of step is 1, indicating 1 day.",
+              "description": "Specifies the granularity that the value must adhere to, or the special value any,\nFor date inputs, the value of step is given in days; and is treated as a number of milliseconds equal to 86,400,000 times the step value.\nThe default value of step is 1, indicating 1 day.",
               "fieldName": "step"
             },
             {
@@ -5230,6 +5218,462 @@
           "declaration": {
             "name": "DateRangePicker",
             "module": "\"./daterangepicker\""
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/reusable/datePicker/datepicker.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Datepicker.",
+          "name": "DatePicker",
+          "slots": [
+            {
+              "description": "Slot for label text.",
+              "name": "unnamed"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "string"
+              },
+              "default": "'md'",
+              "description": "Datepicker size. \"sm\", \"md\", or \"lg\".",
+              "attribute": "size"
+            },
+            {
+              "kind": "field",
+              "name": "caption",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Optional text beneath the input.",
+              "attribute": "caption"
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Datepicker value in YYYY-MM-DD or YYYY-MM-DDThh:mm format.",
+              "attribute": "value",
+              "inheritedFrom": {
+                "name": "FormMixin",
+                "module": "src/common/mixins/form-input.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Makes the date required.",
+              "attribute": "required"
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Date disabled state.",
+              "attribute": "disabled"
+            },
+            {
+              "kind": "field",
+              "name": "warnText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Date warning text",
+              "attribute": "warnText"
+            },
+            {
+              "kind": "field",
+              "name": "maxDate",
+              "type": {
+                "text": "string"
+              },
+              "description": "Maximum date in YYYY-MM-DD or YYYY-MM-DDThh:mm format. If the value isn't a possible date string in the format, then the element has no maximum date value",
+              "attribute": "maxDate"
+            },
+            {
+              "kind": "field",
+              "name": "minDate",
+              "type": {
+                "text": "string"
+              },
+              "description": "Mimimum date in YYYY-MM-DD or YYYY-MM-DDThh:mm format. If the value isn't a possible date string in the format, then the element has no minimum date value.",
+              "attribute": "minDate"
+            },
+            {
+              "kind": "field",
+              "name": "step",
+              "type": {
+                "text": "string"
+              },
+              "description": "Specifies the granularity that the value must adhere to, or the special value any,\nFor date inputs, the value of step is given in days; and is treated as a number of milliseconds equal to 86,400,000 times the step value.\nThe default value of step is 1, indicating 1 day.",
+              "attribute": "step"
+            },
+            {
+              "kind": "field",
+              "name": "datePickerType",
+              "type": {
+                "text": "DATE_PICKER_TYPES"
+              },
+              "description": "Date picker types. Default 'single'",
+              "attribute": "datePickerType"
+            },
+            {
+              "kind": "method",
+              "name": "handleInput",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "any"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_validate",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "interacted",
+                  "type": {
+                    "text": "Boolean"
+                  }
+                },
+                {
+                  "name": "report",
+                  "type": {
+                    "text": "Boolean"
+                  }
+                }
+              ],
+              "description": "Component _validate function reference.",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "FormMixin",
+                "module": "src/common/mixins/form-input.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Input name.",
+              "attribute": "name",
+              "inheritedFrom": {
+                "name": "FormMixin",
+                "module": "src/common/mixins/form-input.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "invalidText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Input invalid text.",
+              "attribute": "invalidText",
+              "inheritedFrom": {
+                "name": "FormMixin",
+                "module": "src/common/mixins/form-input.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "_onUpdated",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "changedProps",
+                  "type": {
+                    "text": "any"
+                  }
+                }
+              ],
+              "inheritedFrom": {
+                "name": "FormMixin",
+                "module": "src/common/mixins/form-input.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "updated",
+              "parameters": [
+                {
+                  "name": "changedProps",
+                  "type": {
+                    "text": "any"
+                  }
+                }
+              ],
+              "inheritedFrom": {
+                "name": "FormMixin",
+                "module": "src/common/mixins/form-input.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "_onConnected",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "FormMixin",
+                "module": "src/common/mixins/form-input.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "_onDisconnected",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "FormMixin",
+                "module": "src/common/mixins/form-input.ts"
+              }
+            }
+          ],
+          "events": [
+            {
+              "description": "Captures the input event and emits the selected value and original event details.",
+              "name": "on-input"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "size",
+              "type": {
+                "text": "string"
+              },
+              "default": "'md'",
+              "description": "Datepicker size. \"sm\", \"md\", or \"lg\".",
+              "fieldName": "size"
+            },
+            {
+              "name": "caption",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Optional text beneath the input.",
+              "fieldName": "caption"
+            },
+            {
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Datepicker value in YYYY-MM-DD or YYYY-MM-DDThh:mm format.",
+              "fieldName": "value",
+              "inheritedFrom": {
+                "name": "FormMixin",
+                "module": "src/common/mixins/form-input.ts"
+              }
+            },
+            {
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Makes the date required.",
+              "fieldName": "required"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Date disabled state.",
+              "fieldName": "disabled"
+            },
+            {
+              "name": "warnText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Date warning text",
+              "fieldName": "warnText"
+            },
+            {
+              "name": "maxDate",
+              "type": {
+                "text": "string"
+              },
+              "description": "Maximum date in YYYY-MM-DD or YYYY-MM-DDThh:mm format. If the value isn't a possible date string in the format, then the element has no maximum date value",
+              "fieldName": "maxDate"
+            },
+            {
+              "name": "minDate",
+              "type": {
+                "text": "string"
+              },
+              "description": "Mimimum date in YYYY-MM-DD or YYYY-MM-DDThh:mm format. If the value isn't a possible date string in the format, then the element has no minimum date value.",
+              "fieldName": "minDate"
+            },
+            {
+              "name": "step",
+              "type": {
+                "text": "string"
+              },
+              "description": "Specifies the granularity that the value must adhere to, or the special value any,\nFor date inputs, the value of step is given in days; and is treated as a number of milliseconds equal to 86,400,000 times the step value.\nThe default value of step is 1, indicating 1 day.",
+              "fieldName": "step"
+            },
+            {
+              "name": "datePickerType",
+              "type": {
+                "text": "DATE_PICKER_TYPES"
+              },
+              "description": "Date picker types. Default 'single'",
+              "fieldName": "datePickerType"
+            },
+            {
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Input name.",
+              "fieldName": "name",
+              "inheritedFrom": {
+                "name": "FormMixin",
+                "module": "src/common/mixins/form-input.ts"
+              }
+            },
+            {
+              "name": "invalidText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Input invalid text.",
+              "fieldName": "invalidText",
+              "inheritedFrom": {
+                "name": "FormMixin",
+                "module": "src/common/mixins/form-input.ts"
+              }
+            }
+          ],
+          "mixins": [
+            {
+              "name": "FormMixin",
+              "module": "/src/common/mixins/form-input"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kyn-date-picker",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "DatePicker",
+          "declaration": {
+            "name": "DatePicker",
+            "module": "src/components/reusable/datePicker/datepicker.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kyn-date-picker",
+          "declaration": {
+            "name": "DatePicker",
+            "module": "src/components/reusable/datePicker/datepicker.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/reusable/datePicker/defs.ts",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "regexDateFormat",
+          "default": "/^\\d{4}-\\d{2}-\\d{2}$/"
+        },
+        {
+          "kind": "variable",
+          "name": "regexDateTimeFormat",
+          "default": "/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}$/"
+        },
+        {
+          "kind": "variable",
+          "name": "regexDateTimeFormatSec",
+          "default": "/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$/"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "regexDateFormat",
+          "declaration": {
+            "name": "regexDateFormat",
+            "module": "src/components/reusable/datePicker/defs.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "regexDateTimeFormat",
+          "declaration": {
+            "name": "regexDateTimeFormat",
+            "module": "src/components/reusable/datePicker/defs.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "regexDateTimeFormatSec",
+          "declaration": {
+            "name": "regexDateTimeFormatSec",
+            "module": "src/components/reusable/datePicker/defs.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/reusable/datePicker/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "DatePicker",
+          "declaration": {
+            "name": "DatePicker",
+            "module": "./datepicker"
           }
         }
       ]
@@ -5704,6 +6148,11 @@
             },
             {
               "kind": "method",
+              "name": "_updateTags",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
               "name": "_updateOptions",
               "privacy": "private"
             },
@@ -5749,16 +6198,6 @@
               "default": "''",
               "description": "Input invalid text.",
               "attribute": "invalidText",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_handleInvalid",
-              "privacy": "private",
-              "description": "Handles the invalid event, triggered on form submit, and runs validation.",
               "inheritedFrom": {
                 "name": "FormMixin",
                 "module": "src/common/mixins/form-input.ts"
@@ -6291,472 +6730,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/reusable/datePicker/datepicker.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "Datepicker.",
-          "name": "DatePicker",
-          "slots": [
-            {
-              "description": "Slot for label text.",
-              "name": "unnamed"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "size",
-              "type": {
-                "text": "string"
-              },
-              "default": "'md'",
-              "description": "Datepicker size. \"sm\", \"md\", or \"lg\".",
-              "attribute": "size"
-            },
-            {
-              "kind": "field",
-              "name": "caption",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Optional text beneath the input.",
-              "attribute": "caption"
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Datepicker value in YYYY-MM-DD or YYYY-MM-DDThh:mm format.",
-              "attribute": "value",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Makes the date required.",
-              "attribute": "required"
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Date disabled state.",
-              "attribute": "disabled"
-            },
-            {
-              "kind": "field",
-              "name": "warnText",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Date warning text",
-              "attribute": "warnText"
-            },
-            {
-              "kind": "field",
-              "name": "maxDate",
-              "type": {
-                "text": "string"
-              },
-              "description": "Maximum date in YYYY-MM-DD or YYYY-MM-DDThh:mm format. If the value isn't a possible date string in the format, then the element has no maximum date value",
-              "attribute": "maxDate"
-            },
-            {
-              "kind": "field",
-              "name": "minDate",
-              "type": {
-                "text": "string"
-              },
-              "description": "Mimimum date in YYYY-MM-DD or YYYY-MM-DDThh:mm format. If the value isn't a possible date string in the format, then the element has no minimum date value.",
-              "attribute": "minDate"
-            },
-            {
-              "kind": "field",
-              "name": "step",
-              "type": {
-                "text": "string"
-              },
-              "description": "Specifies the granularity that the value must adhere to, or the special value any,\r\nFor date inputs, the value of step is given in days; and is treated as a number of milliseconds equal to 86,400,000 times the step value.\r\nThe default value of step is 1, indicating 1 day.",
-              "attribute": "step"
-            },
-            {
-              "kind": "field",
-              "name": "datePickerType",
-              "type": {
-                "text": "DATE_PICKER_TYPES"
-              },
-              "description": "Date picker types. Default 'single'",
-              "attribute": "datePickerType"
-            },
-            {
-              "kind": "method",
-              "name": "handleInput",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "any"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_validate",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "interacted",
-                  "type": {
-                    "text": "Boolean"
-                  }
-                },
-                {
-                  "name": "report",
-                  "type": {
-                    "text": "Boolean"
-                  }
-                }
-              ],
-              "description": "Component _validate function reference.",
-              "privacy": "private",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Input name.",
-              "attribute": "name",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "invalidText",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Input invalid text.",
-              "attribute": "invalidText",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_handleInvalid",
-              "privacy": "private",
-              "description": "Handles the invalid event, triggered on form submit, and runs validation.",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_onUpdated",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "changedProps",
-                  "type": {
-                    "text": "any"
-                  }
-                }
-              ],
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "updated",
-              "parameters": [
-                {
-                  "name": "changedProps",
-                  "type": {
-                    "text": "any"
-                  }
-                }
-              ],
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_onConnected",
-              "privacy": "private",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_onDisconnected",
-              "privacy": "private",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            }
-          ],
-          "events": [
-            {
-              "description": "Captures the input event and emits the selected value and original event details.",
-              "name": "on-input"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "size",
-              "type": {
-                "text": "string"
-              },
-              "default": "'md'",
-              "description": "Datepicker size. \"sm\", \"md\", or \"lg\".",
-              "fieldName": "size"
-            },
-            {
-              "name": "caption",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Optional text beneath the input.",
-              "fieldName": "caption"
-            },
-            {
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Datepicker value in YYYY-MM-DD or YYYY-MM-DDThh:mm format.",
-              "fieldName": "value",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Makes the date required.",
-              "fieldName": "required"
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Date disabled state.",
-              "fieldName": "disabled"
-            },
-            {
-              "name": "warnText",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Date warning text",
-              "fieldName": "warnText"
-            },
-            {
-              "name": "maxDate",
-              "type": {
-                "text": "string"
-              },
-              "description": "Maximum date in YYYY-MM-DD or YYYY-MM-DDThh:mm format. If the value isn't a possible date string in the format, then the element has no maximum date value",
-              "fieldName": "maxDate"
-            },
-            {
-              "name": "minDate",
-              "type": {
-                "text": "string"
-              },
-              "description": "Mimimum date in YYYY-MM-DD or YYYY-MM-DDThh:mm format. If the value isn't a possible date string in the format, then the element has no minimum date value.",
-              "fieldName": "minDate"
-            },
-            {
-              "name": "step",
-              "type": {
-                "text": "string"
-              },
-              "description": "Specifies the granularity that the value must adhere to, or the special value any,\r\nFor date inputs, the value of step is given in days; and is treated as a number of milliseconds equal to 86,400,000 times the step value.\r\nThe default value of step is 1, indicating 1 day.",
-              "fieldName": "step"
-            },
-            {
-              "name": "datePickerType",
-              "type": {
-                "text": "DATE_PICKER_TYPES"
-              },
-              "description": "Date picker types. Default 'single'",
-              "fieldName": "datePickerType"
-            },
-            {
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Input name.",
-              "fieldName": "name",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "name": "invalidText",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Input invalid text.",
-              "fieldName": "invalidText",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            }
-          ],
-          "mixins": [
-            {
-              "name": "FormMixin",
-              "module": "/src/common/mixins/form-input"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "kyn-date-picker",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "DatePicker",
-          "declaration": {
-            "name": "DatePicker",
-            "module": "src/components/reusable/datePicker/datepicker.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "kyn-date-picker",
-          "declaration": {
-            "name": "DatePicker",
-            "module": "src/components/reusable/datePicker/datepicker.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/reusable/datePicker/defs.ts",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "regexDateFormat",
-          "default": "/^\\d{4}-\\d{2}-\\d{2}$/"
-        },
-        {
-          "kind": "variable",
-          "name": "regexDateTimeFormat",
-          "default": "/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}$/"
-        },
-        {
-          "kind": "variable",
-          "name": "regexDateTimeFormatSec",
-          "default": "/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$/"
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "regexDateFormat",
-          "declaration": {
-            "name": "regexDateFormat",
-            "module": "src/components/reusable/datePicker/defs.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "regexDateTimeFormat",
-          "declaration": {
-            "name": "regexDateTimeFormat",
-            "module": "src/components/reusable/datePicker/defs.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "regexDateTimeFormatSec",
-          "declaration": {
-            "name": "regexDateTimeFormatSec",
-            "module": "src/components/reusable/datePicker/defs.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/reusable/datePicker/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "DatePicker",
-          "declaration": {
-            "name": "DatePicker",
-            "module": "./datepicker"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/components/reusable/globalFilter/globalFilter.chart.sample.ts",
       "declarations": [
         {
@@ -6770,7 +6743,7 @@
               "type": {
                 "text": "Array<any>"
               },
-              "default": "[\r\n    {\r\n      value: 'Red',\r\n      text: 'Red',\r\n    },\r\n    {\r\n      value: 'Blue',\r\n      text: 'Blue',\r\n    },\r\n    {\r\n      value: 'Yellow',\r\n      text: 'Yellow',\r\n    },\r\n    {\r\n      value: 'Green',\r\n      text: 'Green',\r\n    },\r\n    {\r\n      value: 'Purple',\r\n      text: 'Purple',\r\n    },\r\n    {\r\n      value: 'Orange',\r\n      text: 'Orange',\r\n    },\r\n  ]",
+              "default": "[\n    {\n      value: 'Red',\n      text: 'Red',\n    },\n    {\n      value: 'Blue',\n      text: 'Blue',\n    },\n    {\n      value: 'Yellow',\n      text: 'Yellow',\n    },\n    {\n      value: 'Green',\n      text: 'Green',\n    },\n    {\n      value: 'Purple',\n      text: 'Purple',\n    },\n    {\n      value: 'Orange',\n      text: 'Orange',\n    },\n  ]",
               "description": "Array of sample checkbox filter options.",
               "attribute": "checkboxOptions"
             },
@@ -6780,7 +6753,7 @@
               "type": {
                 "text": "Array<string>"
               },
-              "default": "[\r\n    'Red',\r\n    'Blue',\r\n    'Yellow',\r\n    'Green',\r\n    'Purple',\r\n    'Orange',\r\n  ]",
+              "default": "[\n    'Red',\n    'Blue',\n    'Yellow',\n    'Green',\n    'Purple',\n    'Orange',\n  ]",
               "attribute": "chartLabels"
             },
             {
@@ -6798,7 +6771,7 @@
               "type": {
                 "text": "Array<any>"
               },
-              "default": "[\r\n    {\r\n      label: 'Dataset 1',\r\n      data: [12, 19, 3, 5, 2, 3],\r\n    },\r\n    {\r\n      label: 'Dataset 2',\r\n      data: [8, 15, 7, 9, 6, 13],\r\n    },\r\n  ]",
+              "default": "[\n    {\n      label: 'Dataset 1',\n      data: [12, 19, 3, 5, 2, 3],\n    },\n    {\n      label: 'Dataset 2',\n      data: [8, 15, 7, 9, 6, 13],\n    },\n  ]",
               "attribute": "chartDatasets"
             },
             {
@@ -6807,7 +6780,7 @@
               "type": {
                 "text": "object"
               },
-              "default": "{\r\n    scales: {\r\n      x: {\r\n        title: {\r\n          text: 'Color',\r\n        },\r\n      },\r\n      y: {\r\n        title: {\r\n          text: 'Votes',\r\n        },\r\n      },\r\n    },\r\n  }",
+              "default": "{\n    scales: {\n      x: {\n        title: {\n          text: 'Color',\n        },\n      },\n      y: {\n        title: {\n          text: 'Votes',\n        },\n      },\n    },\n  }",
               "attribute": "chartOptions"
             },
             {
@@ -6901,7 +6874,7 @@
               "type": {
                 "text": "Array<any>"
               },
-              "default": "[\r\n    {\r\n      value: 'Red',\r\n      text: 'Red',\r\n    },\r\n    {\r\n      value: 'Blue',\r\n      text: 'Blue',\r\n    },\r\n    {\r\n      value: 'Yellow',\r\n      text: 'Yellow',\r\n    },\r\n    {\r\n      value: 'Green',\r\n      text: 'Green',\r\n    },\r\n    {\r\n      value: 'Purple',\r\n      text: 'Purple',\r\n    },\r\n    {\r\n      value: 'Orange',\r\n      text: 'Orange',\r\n    },\r\n  ]",
+              "default": "[\n    {\n      value: 'Red',\n      text: 'Red',\n    },\n    {\n      value: 'Blue',\n      text: 'Blue',\n    },\n    {\n      value: 'Yellow',\n      text: 'Yellow',\n    },\n    {\n      value: 'Green',\n      text: 'Green',\n    },\n    {\n      value: 'Purple',\n      text: 'Purple',\n    },\n    {\n      value: 'Orange',\n      text: 'Orange',\n    },\n  ]",
               "description": "Array of sample checkbox filter options.",
               "fieldName": "checkboxOptions"
             },
@@ -6910,7 +6883,7 @@
               "type": {
                 "text": "Array<string>"
               },
-              "default": "[\r\n    'Red',\r\n    'Blue',\r\n    'Yellow',\r\n    'Green',\r\n    'Purple',\r\n    'Orange',\r\n  ]",
+              "default": "[\n    'Red',\n    'Blue',\n    'Yellow',\n    'Green',\n    'Purple',\n    'Orange',\n  ]",
               "fieldName": "chartLabels"
             },
             {
@@ -6926,7 +6899,7 @@
               "type": {
                 "text": "Array<any>"
               },
-              "default": "[\r\n    {\r\n      label: 'Dataset 1',\r\n      data: [12, 19, 3, 5, 2, 3],\r\n    },\r\n    {\r\n      label: 'Dataset 2',\r\n      data: [8, 15, 7, 9, 6, 13],\r\n    },\r\n  ]",
+              "default": "[\n    {\n      label: 'Dataset 1',\n      data: [12, 19, 3, 5, 2, 3],\n    },\n    {\n      label: 'Dataset 2',\n      data: [8, 15, 7, 9, 6, 13],\n    },\n  ]",
               "fieldName": "chartDatasets"
             },
             {
@@ -6934,7 +6907,7 @@
               "type": {
                 "text": "object"
               },
-              "default": "{\r\n    scales: {\r\n      x: {\r\n        title: {\r\n          text: 'Color',\r\n        },\r\n      },\r\n      y: {\r\n        title: {\r\n          text: 'Votes',\r\n        },\r\n      },\r\n    },\r\n  }",
+              "default": "{\n    scales: {\n      x: {\n        title: {\n          text: 'Color',\n        },\n      },\n      y: {\n        title: {\n          text: 'Votes',\n        },\n      },\n    },\n  }",
               "fieldName": "chartOptions"
             }
           ],
@@ -6980,7 +6953,7 @@
               "type": {
                 "text": "Array<any>"
               },
-              "default": "[\r\n    {\r\n      value: '1',\r\n      text: 'Option 1',\r\n    },\r\n    {\r\n      value: '2',\r\n      text: 'Option 2',\r\n    },\r\n    {\r\n      value: '3',\r\n      text: 'Option 3',\r\n    },\r\n    {\r\n      value: '4',\r\n      text: 'Option 4',\r\n    },\r\n    {\r\n      value: '5',\r\n      text: 'Option 5',\r\n    },\r\n    {\r\n      value: '6',\r\n      text: 'Option 6',\r\n    },\r\n  ]",
+              "default": "[\n    {\n      value: '1',\n      text: 'Option 1',\n    },\n    {\n      value: '2',\n      text: 'Option 2',\n    },\n    {\n      value: '3',\n      text: 'Option 3',\n    },\n    {\n      value: '4',\n      text: 'Option 4',\n    },\n    {\n      value: '5',\n      text: 'Option 5',\n    },\n    {\n      value: '6',\n      text: 'Option 6',\n    },\n  ]",
               "description": "Array of sample checkbox filter options.",
               "attribute": "checkboxOptions"
             },
@@ -7088,7 +7061,7 @@
               "type": {
                 "text": "Array<any>"
               },
-              "default": "[\r\n    {\r\n      value: '1',\r\n      text: 'Option 1',\r\n    },\r\n    {\r\n      value: '2',\r\n      text: 'Option 2',\r\n    },\r\n    {\r\n      value: '3',\r\n      text: 'Option 3',\r\n    },\r\n    {\r\n      value: '4',\r\n      text: 'Option 4',\r\n    },\r\n    {\r\n      value: '5',\r\n      text: 'Option 5',\r\n    },\r\n    {\r\n      value: '6',\r\n      text: 'Option 6',\r\n    },\r\n  ]",
+              "default": "[\n    {\n      value: '1',\n      text: 'Option 1',\n    },\n    {\n      value: '2',\n      text: 'Option 2',\n    },\n    {\n      value: '3',\n      text: 'Option 3',\n    },\n    {\n      value: '4',\n      text: 'Option 4',\n    },\n    {\n      value: '5',\n      text: 'Option 5',\n    },\n    {\n      value: '6',\n      text: 'Option 6',\n    },\n  ]",
               "description": "Array of sample checkbox filter options.",
               "fieldName": "checkboxOptions"
             }
@@ -7135,7 +7108,7 @@
               "type": {
                 "text": "Array<any>"
               },
-              "default": "[\r\n    {\r\n      value: 'Stark',\r\n      text: 'Stark',\r\n    },\r\n    {\r\n      value: 'Lannister',\r\n      text: 'Lannister',\r\n    },\r\n    {\r\n      value: 'Targaryen',\r\n      text: 'Targaryen',\r\n    },\r\n  ]",
+              "default": "[\n    {\n      value: 'Stark',\n      text: 'Stark',\n    },\n    {\n      value: 'Lannister',\n      text: 'Lannister',\n    },\n    {\n      value: 'Targaryen',\n      text: 'Targaryen',\n    },\n  ]",
               "description": "Array of sample checkbox filter options."
             },
             {
@@ -7161,7 +7134,7 @@
                 "text": "array"
               },
               "privacy": "private",
-              "default": "[\r\n    { name: 'Jon Snow', age: 23, house: 'Stark' },\r\n    { name: 'Daenerys Targaryen', age: 22, house: 'Targaryen' },\r\n    { name: 'Tyrion Lannister', age: 39, house: 'Lannister' },\r\n    { name: 'Cersei Lannister', age: 42, house: 'Lannister' },\r\n    { name: 'Arya Stark', age: 18, house: 'Stark' },\r\n    { name: 'Sansa Stark', age: 20, house: 'Stark' },\r\n    { name: 'Bran Stark', age: 17, house: 'Stark' },\r\n    { name: 'Jaime Lannister', age: 44, house: 'Lannister' },\r\n  ]"
+              "default": "[\n    { name: 'Jon Snow', age: 23, house: 'Stark' },\n    { name: 'Daenerys Targaryen', age: 22, house: 'Targaryen' },\n    { name: 'Tyrion Lannister', age: 39, house: 'Lannister' },\n    { name: 'Cersei Lannister', age: 42, house: 'Lannister' },\n    { name: 'Arya Stark', age: 18, house: 'Stark' },\n    { name: 'Sansa Stark', age: 20, house: 'Stark' },\n    { name: 'Bran Stark', age: 17, house: 'Stark' },\n    { name: 'Jaime Lannister', age: 44, house: 'Lannister' },\n  ]"
             },
             {
               "kind": "field",
@@ -7170,7 +7143,7 @@
                 "text": "array"
               },
               "privacy": "private",
-              "default": "[\r\n    { name: 'Jon Snow', age: 23, house: 'Stark' },\r\n    { name: 'Daenerys Targaryen', age: 22, house: 'Targaryen' },\r\n    { name: 'Tyrion Lannister', age: 39, house: 'Lannister' },\r\n    { name: 'Cersei Lannister', age: 42, house: 'Lannister' },\r\n    { name: 'Arya Stark', age: 18, house: 'Stark' },\r\n    { name: 'Sansa Stark', age: 20, house: 'Stark' },\r\n    { name: 'Bran Stark', age: 17, house: 'Stark' },\r\n    { name: 'Jaime Lannister', age: 44, house: 'Lannister' },\r\n  ]"
+              "default": "[\n    { name: 'Jon Snow', age: 23, house: 'Stark' },\n    { name: 'Daenerys Targaryen', age: 22, house: 'Targaryen' },\n    { name: 'Tyrion Lannister', age: 39, house: 'Lannister' },\n    { name: 'Cersei Lannister', age: 42, house: 'Lannister' },\n    { name: 'Arya Stark', age: 18, house: 'Stark' },\n    { name: 'Sansa Stark', age: 20, house: 'Stark' },\n    { name: 'Bran Stark', age: 17, house: 'Stark' },\n    { name: 'Jaime Lannister', age: 44, house: 'Lannister' },\n  ]"
             },
             {
               "kind": "field",
@@ -7865,6 +7838,16 @@
               "description": "Function to execute before the modal can close. Useful for running checks or validations before closing. Exposes `returnValue` (`'ok'` or `'cancel'`). Must return `true` or `false`."
             },
             {
+              "kind": "field",
+              "name": "closeText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Close'",
+              "description": "Close button text.",
+              "attribute": "closeText"
+            },
+            {
               "kind": "method",
               "name": "_openModal",
               "privacy": "private"
@@ -8025,6 +8008,15 @@
               "default": "false",
               "description": "Hides the cancel button.",
               "fieldName": "hideCancelButton"
+            },
+            {
+              "name": "closeText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Close'",
+              "description": "Close button text.",
+              "fieldName": "closeText"
             }
           ],
           "superclass": {
@@ -8162,7 +8154,7 @@
               "type": {
                 "text": "any"
               },
-              "default": "{\r\n    success: 'Success',\r\n    warning: 'Warning',\r\n    info: 'Info',\r\n    error: 'Error',\r\n  }",
+              "default": "{\n    success: 'Success',\n    warning: 'Warning',\n    info: 'Info',\n    error: 'Error',\n  }",
               "description": "Customizable text strings.",
               "attribute": "textStrings"
             },
@@ -8296,7 +8288,7 @@
               "type": {
                 "text": "any"
               },
-              "default": "{\r\n    success: 'Success',\r\n    warning: 'Warning',\r\n    info: 'Info',\r\n    error: 'Error',\r\n  }",
+              "default": "{\n    success: 'Success',\n    warning: 'Warning',\n    info: 'Info',\n    error: 'Error',\n  }",
               "description": "Customizable text strings.",
               "fieldName": "textStrings"
             },
@@ -8361,7 +8353,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "Notification container component for Toast notification.\r\nUsage is limited for <kyn-notification type=\"toast\">..</kyn-notification>",
+          "description": "Notification container component for Toast notification.\nUsage is limited for <kyn-notification type=\"toast\">..</kyn-notification>",
           "name": "NotificationContainer",
           "slots": [
             {
@@ -8535,7 +8527,7 @@
               "type": {
                 "text": "object"
               },
-              "default": "{\r\n    subtract: 'Subtract',\r\n    add: 'Add',\r\n  }",
+              "default": "{\n    subtract: 'Subtract',\n    add: 'Add',\n  }",
               "description": "Customizable text strings.",
               "attribute": "textStrings"
             },
@@ -8641,16 +8633,6 @@
               "default": "''",
               "description": "Input invalid text.",
               "attribute": "invalidText",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_handleInvalid",
-              "privacy": "private",
-              "description": "Handles the invalid event, triggered on form submit, and runs validation.",
               "inheritedFrom": {
                 "name": "FormMixin",
                 "module": "src/common/mixins/form-input.ts"
@@ -8812,7 +8794,7 @@
               "type": {
                 "text": "object"
               },
-              "default": "{\r\n    subtract: 'Subtract',\r\n    add: 'Add',\r\n  }",
+              "default": "{\n    subtract: 'Subtract',\n    add: 'Add',\n  }",
               "description": "Customizable text strings.",
               "fieldName": "textStrings"
             },
@@ -9332,6 +9314,262 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/reusable/pagination/Pagination.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "`kyn-pagination` Web Component.\n\nA component that provides pagination functionality, enabling the user to\nnavigate through large datasets by splitting them into discrete chunks.\nIntegrates with other utility components like items range display, page size dropdown,\nand navigation buttons.",
+          "name": "Pagination",
+          "members": [
+            {
+              "kind": "field",
+              "name": "count",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "description": "Total number of items that need pagination.",
+              "attribute": "count",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "pageNumber",
+              "type": {
+                "text": "number"
+              },
+              "default": "1",
+              "description": "Current active page number.",
+              "attribute": "pageNumber",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "pageSize",
+              "type": {
+                "text": "number"
+              },
+              "default": "5",
+              "description": "Number of items displayed per page.",
+              "attribute": "pageSize",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "pageSizeOptions",
+              "type": {
+                "text": "number[]"
+              },
+              "default": "[5, 10, 20, 30, 40, 50, 100]",
+              "description": "Available options for the page size.",
+              "attribute": "pageSizeOptions"
+            },
+            {
+              "kind": "field",
+              "name": "_numberOfPages",
+              "type": {
+                "text": "number"
+              },
+              "default": "1",
+              "description": "Number of pages."
+            },
+            {
+              "kind": "field",
+              "name": "pageSizeLabel",
+              "default": "PAGE_SIZE_LABEL",
+              "description": "Label for the page size dropdown.",
+              "attribute": "pageSizeLabel"
+            },
+            {
+              "kind": "field",
+              "name": "hideItemsRange",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Option to hide the items range display.",
+              "attribute": "hideItemsRange"
+            },
+            {
+              "kind": "field",
+              "name": "hidePageSizeDropdown",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Option to hide the page size dropdown.",
+              "attribute": "hidePageSizeDropdown"
+            },
+            {
+              "kind": "field",
+              "name": "hideNavigationButtons",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Option to hide the navigation buttons.",
+              "attribute": "hideNavigationButtons"
+            },
+            {
+              "kind": "field",
+              "name": "textStrings",
+              "type": {
+                "text": "object"
+              },
+              "default": "{\n    showing: 'Showing',\n    of: 'of',\n    items: 'items',\n    pages: 'pages',\n    itemsPerPage: 'Items per page:',\n    previousPage: 'Previous page',\n    nextPage: 'Next page',\n  }",
+              "description": "Customizable text strings",
+              "attribute": "textStrings"
+            },
+            {
+              "kind": "method",
+              "name": "handlePageSizeChange",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "CustomEvent"
+                  },
+                  "description": "The emitted custom event with the selected page size."
+                }
+              ],
+              "description": "Handler for the event when the page size is changed by the user.\nUpdates the `pageSize` and resets the `pageNumber` to 1."
+            },
+            {
+              "kind": "method",
+              "name": "handlePageNumberChange",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "CustomEvent"
+                  },
+                  "description": "The emitted custom event with the selected page number."
+                }
+              ],
+              "description": "Handler for the event when the page number is changed by the user.\nUpdates the `pageNumber`."
+            }
+          ],
+          "events": [
+            {
+              "description": "Dispatched when the page size changes.",
+              "name": "on-page-size-change"
+            },
+            {
+              "description": "Dispatched when the currently active page changes.",
+              "name": "on-page-number-change"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "count",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "description": "Total number of items that need pagination.",
+              "fieldName": "count"
+            },
+            {
+              "name": "pageNumber",
+              "type": {
+                "text": "number"
+              },
+              "default": "1",
+              "description": "Current active page number.",
+              "fieldName": "pageNumber"
+            },
+            {
+              "name": "pageSize",
+              "type": {
+                "text": "number"
+              },
+              "default": "5",
+              "description": "Number of items displayed per page.",
+              "fieldName": "pageSize"
+            },
+            {
+              "name": "pageSizeOptions",
+              "type": {
+                "text": "number[]"
+              },
+              "default": "[5, 10, 20, 30, 40, 50, 100]",
+              "description": "Available options for the page size.",
+              "fieldName": "pageSizeOptions"
+            },
+            {
+              "name": "pageSizeLabel",
+              "default": "PAGE_SIZE_LABEL",
+              "description": "Label for the page size dropdown.",
+              "fieldName": "pageSizeLabel"
+            },
+            {
+              "name": "hideItemsRange",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Option to hide the items range display.",
+              "fieldName": "hideItemsRange"
+            },
+            {
+              "name": "hidePageSizeDropdown",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Option to hide the page size dropdown.",
+              "fieldName": "hidePageSizeDropdown"
+            },
+            {
+              "name": "hideNavigationButtons",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Option to hide the navigation buttons.",
+              "fieldName": "hideNavigationButtons"
+            },
+            {
+              "name": "textStrings",
+              "type": {
+                "text": "object"
+              },
+              "default": "{\n    showing: 'Showing',\n    of: 'of',\n    items: 'items',\n    pages: 'pages',\n    itemsPerPage: 'Items per page:',\n    previousPage: 'Previous page',\n    nextPage: 'Next page',\n  }",
+              "description": "Customizable text strings",
+              "fieldName": "textStrings"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kyn-pagination",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Pagination",
+          "declaration": {
+            "name": "Pagination",
+            "module": "src/components/reusable/pagination/Pagination.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kyn-pagination",
+          "declaration": {
+            "name": "Pagination",
+            "module": "src/components/reusable/pagination/Pagination.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/reusable/pagination/constants.ts",
       "declarations": [
         {
@@ -9479,7 +9717,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-pagination-items-range` Web Component.\r\n\r\nThis component is responsible for displaying the range of items being displayed\r\nin the context of pagination. It shows which items (by number) are currently visible\r\nand the total number of items.",
+          "description": "`kyn-pagination-items-range` Web Component.\n\nThis component is responsible for displaying the range of items being displayed\nin the context of pagination. It shows which items (by number) are currently visible\nand the total number of items.",
           "name": "PaginationItemsRange",
           "members": [
             {
@@ -9596,7 +9834,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-pagination-navigation-buttons` Web Component.\r\n\r\nThis component provides navigational controls for pagination.\r\nIt includes back and next buttons, along with displaying the current page and total pages.",
+          "description": "`kyn-pagination-navigation-buttons` Web Component.\n\nThis component provides navigational controls for pagination.\nIt includes back and next buttons, along with displaying the current page and total pages.",
           "name": "PaginationNavigationButtons",
           "members": [
             {
@@ -9705,7 +9943,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-pagination-page-size-dropdown` Web Component.\r\n\r\nThis component provides a dropdown to select the page size for pagination.\r\nIt emits events when the selected page size changes.",
+          "description": "`kyn-pagination-page-size-dropdown` Web Component.\n\nThis component provides a dropdown to select the page size for pagination.\nIt emits events when the selected page size changes.",
           "name": "PaginationPageSizeDropdown",
           "members": [
             {
@@ -9797,262 +10035,6 @@
           "declaration": {
             "name": "PaginationPageSizeDropdown",
             "module": "src/components/reusable/pagination/pagination-page-size-dropdown.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/reusable/pagination/Pagination.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "`kyn-pagination` Web Component.\r\n\r\nA component that provides pagination functionality, enabling the user to\r\nnavigate through large datasets by splitting them into discrete chunks.\r\nIntegrates with other utility components like items range display, page size dropdown,\r\nand navigation buttons.",
-          "name": "Pagination",
-          "members": [
-            {
-              "kind": "field",
-              "name": "count",
-              "type": {
-                "text": "number"
-              },
-              "default": "0",
-              "description": "Total number of items that need pagination.",
-              "attribute": "count",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "pageNumber",
-              "type": {
-                "text": "number"
-              },
-              "default": "1",
-              "description": "Current active page number.",
-              "attribute": "pageNumber",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "pageSize",
-              "type": {
-                "text": "number"
-              },
-              "default": "5",
-              "description": "Number of items displayed per page.",
-              "attribute": "pageSize",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "pageSizeOptions",
-              "type": {
-                "text": "number[]"
-              },
-              "default": "[5, 10, 20, 30, 40, 50, 100]",
-              "description": "Available options for the page size.",
-              "attribute": "pageSizeOptions"
-            },
-            {
-              "kind": "field",
-              "name": "_numberOfPages",
-              "type": {
-                "text": "number"
-              },
-              "default": "1",
-              "description": "Number of pages."
-            },
-            {
-              "kind": "field",
-              "name": "pageSizeLabel",
-              "default": "PAGE_SIZE_LABEL",
-              "description": "Label for the page size dropdown.",
-              "attribute": "pageSizeLabel"
-            },
-            {
-              "kind": "field",
-              "name": "hideItemsRange",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Option to hide the items range display.",
-              "attribute": "hideItemsRange"
-            },
-            {
-              "kind": "field",
-              "name": "hidePageSizeDropdown",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Option to hide the page size dropdown.",
-              "attribute": "hidePageSizeDropdown"
-            },
-            {
-              "kind": "field",
-              "name": "hideNavigationButtons",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Option to hide the navigation buttons.",
-              "attribute": "hideNavigationButtons"
-            },
-            {
-              "kind": "field",
-              "name": "textStrings",
-              "type": {
-                "text": "object"
-              },
-              "default": "{\r\n    showing: 'Showing',\r\n    of: 'of',\r\n    items: 'items',\r\n    pages: 'pages',\r\n    itemsPerPage: 'Items per page:',\r\n    previousPage: 'Previous page',\r\n    nextPage: 'Next page',\r\n  }",
-              "description": "Customizable text strings",
-              "attribute": "textStrings"
-            },
-            {
-              "kind": "method",
-              "name": "handlePageSizeChange",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "CustomEvent"
-                  },
-                  "description": "The emitted custom event with the selected page size."
-                }
-              ],
-              "description": "Handler for the event when the page size is changed by the user.\r\nUpdates the `pageSize` and resets the `pageNumber` to 1."
-            },
-            {
-              "kind": "method",
-              "name": "handlePageNumberChange",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "CustomEvent"
-                  },
-                  "description": "The emitted custom event with the selected page number."
-                }
-              ],
-              "description": "Handler for the event when the page number is changed by the user.\r\nUpdates the `pageNumber`."
-            }
-          ],
-          "events": [
-            {
-              "description": "Dispatched when the page size changes.",
-              "name": "on-page-size-change"
-            },
-            {
-              "description": "Dispatched when the currently active page changes.",
-              "name": "on-page-number-change"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "count",
-              "type": {
-                "text": "number"
-              },
-              "default": "0",
-              "description": "Total number of items that need pagination.",
-              "fieldName": "count"
-            },
-            {
-              "name": "pageNumber",
-              "type": {
-                "text": "number"
-              },
-              "default": "1",
-              "description": "Current active page number.",
-              "fieldName": "pageNumber"
-            },
-            {
-              "name": "pageSize",
-              "type": {
-                "text": "number"
-              },
-              "default": "5",
-              "description": "Number of items displayed per page.",
-              "fieldName": "pageSize"
-            },
-            {
-              "name": "pageSizeOptions",
-              "type": {
-                "text": "number[]"
-              },
-              "default": "[5, 10, 20, 30, 40, 50, 100]",
-              "description": "Available options for the page size.",
-              "fieldName": "pageSizeOptions"
-            },
-            {
-              "name": "pageSizeLabel",
-              "default": "PAGE_SIZE_LABEL",
-              "description": "Label for the page size dropdown.",
-              "fieldName": "pageSizeLabel"
-            },
-            {
-              "name": "hideItemsRange",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Option to hide the items range display.",
-              "fieldName": "hideItemsRange"
-            },
-            {
-              "name": "hidePageSizeDropdown",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Option to hide the page size dropdown.",
-              "fieldName": "hidePageSizeDropdown"
-            },
-            {
-              "name": "hideNavigationButtons",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Option to hide the navigation buttons.",
-              "fieldName": "hideNavigationButtons"
-            },
-            {
-              "name": "textStrings",
-              "type": {
-                "text": "object"
-              },
-              "default": "{\r\n    showing: 'Showing',\r\n    of: 'of',\r\n    items: 'items',\r\n    pages: 'pages',\r\n    itemsPerPage: 'Items per page:',\r\n    previousPage: 'Previous page',\r\n    nextPage: 'Next page',\r\n  }",
-              "description": "Customizable text strings",
-              "fieldName": "textStrings"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "kyn-pagination",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "Pagination",
-          "declaration": {
-            "name": "Pagination",
-            "module": "src/components/reusable/pagination/Pagination.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "kyn-pagination",
-          "declaration": {
-            "name": "Pagination",
-            "module": "src/components/reusable/pagination/Pagination.ts"
           }
         }
       ]
@@ -10234,7 +10216,7 @@
             {
               "kind": "field",
               "name": "textStrings",
-              "default": "{\r\n  required: 'Required',\r\n  error: 'Error',\r\n}",
+              "default": "{\n  required: 'Required',\n  error: 'Error',\n}",
               "description": "Text string customization.",
               "attribute": "textStrings",
               "type": {
@@ -10320,16 +10302,6 @@
               "default": "''",
               "description": "Input invalid text.",
               "attribute": "invalidText",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_handleInvalid",
-              "privacy": "private",
-              "description": "Handles the invalid event, triggered on form submit, and runs validation.",
               "inheritedFrom": {
                 "name": "FormMixin",
                 "module": "src/common/mixins/form-input.ts"
@@ -11174,7 +11146,7 @@
                 "text": "string"
               },
               "default": "'procedure'",
-              "description": "Stepper type `'procedure'` & `'status'`.\r\n\r\nprocedure: Allows a user to move through a series of steps that need to be completed, such as filling out a series of forms. The user can therefore know where they are in the sequence, and can go back to previous steps if needed. Procedure should use the `'large'` size stepper.\r\n\r\nstatus: Should not allow the user navigate to previous steps for ex: sequential forms, payment gateway etc. Should use the `'small'` size to avoid unnecessary clutter.\r\n\r\nNote: Read the stepper guidelines for more info.",
+              "description": "Stepper type `'procedure'` & `'status'`.\n\nprocedure: Allows a user to move through a series of steps that need to be completed, such as filling out a series of forms. The user can therefore know where they are in the sequence, and can go back to previous steps if needed. Procedure should use the `'large'` size stepper.\n\nstatus: Should not allow the user navigate to previous steps for ex: sequential forms, payment gateway etc. Should use the `'small'` size to avoid unnecessary clutter.\n\nNote: Read the stepper guidelines for more info.",
               "attribute": "stepperType"
             },
             {
@@ -11234,7 +11206,7 @@
                 "text": "string"
               },
               "default": "'procedure'",
-              "description": "Stepper type `'procedure'` & `'status'`.\r\n\r\nprocedure: Allows a user to move through a series of steps that need to be completed, such as filling out a series of forms. The user can therefore know where they are in the sequence, and can go back to previous steps if needed. Procedure should use the `'large'` size stepper.\r\n\r\nstatus: Should not allow the user navigate to previous steps for ex: sequential forms, payment gateway etc. Should use the `'small'` size to avoid unnecessary clutter.\r\n\r\nNote: Read the stepper guidelines for more info.",
+              "description": "Stepper type `'procedure'` & `'status'`.\n\nprocedure: Allows a user to move through a series of steps that need to be completed, such as filling out a series of forms. The user can therefore know where they are in the sequence, and can go back to previous steps if needed. Procedure should use the `'large'` size stepper.\n\nstatus: Should not allow the user navigate to previous steps for ex: sequential forms, payment gateway etc. Should use the `'small'` size to avoid unnecessary clutter.\n\nNote: Read the stepper guidelines for more info.",
               "fieldName": "stepperType"
             },
             {
@@ -11362,7 +11334,7 @@
                 "text": "string"
               },
               "default": "'pending'",
-              "description": "Step state. `'pending'`, `'active'`, `'completed'`, `'excluded'`, `'warning'` & `'destructive'`.\r\n\r\n`'pending'`, `'active'` and `'completed'` / `'excluded'` states has 0%, 50% & 100% progress set internally.",
+              "description": "Step state. `'pending'`, `'active'`, `'completed'`, `'excluded'`, `'warning'` & `'destructive'`.\n\n`'pending'`, `'active'` and `'completed'` / `'excluded'` states has 0%, 50% & 100% progress set internally.",
               "attribute": "stepState"
             },
             {
@@ -11468,7 +11440,7 @@
                 "text": "string"
               },
               "default": "'pending'",
-              "description": "Step state. `'pending'`, `'active'`, `'completed'`, `'excluded'`, `'warning'` & `'destructive'`.\r\n\r\n`'pending'`, `'active'` and `'completed'` / `'excluded'` states has 0%, 50% & 100% progress set internally.",
+              "description": "Step state. `'pending'`, `'active'`, `'completed'`, `'excluded'`, `'warning'` & `'destructive'`.\n\n`'pending'`, `'active'` and `'completed'` / `'excluded'` states has 0%, 50% & 100% progress set internally.",
               "fieldName": "stepState"
             },
             {
@@ -11654,7 +11626,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "DEPRECATED. `kyn-data-table` Web Component.\r\nThis component provides a table with sorting, pagination, and selection capabilities.\r\nIt is designed to be used with the `kyn-table-toolbar` and `kyn-table-container` components.",
+          "description": "DEPRECATED. `kyn-data-table` Web Component.\nThis component provides a table with sorting, pagination, and selection capabilities.\nIt is designed to be used with the `kyn-table-toolbar` and `kyn-table-container` components.",
           "name": "DataTable",
           "members": [
             {
@@ -11674,7 +11646,7 @@
                 "text": "ColumnDefinition[]"
               },
               "default": "[]",
-              "description": "columns: Array of objects defining column properties such as\r\nfield name, sorting function, etc.",
+              "description": "columns: Array of objects defining column properties such as\nfield name, sorting function, etc.",
               "attribute": "columns"
             },
             {
@@ -11684,7 +11656,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "checkboxSelection: Boolean indicating whether rows should be\r\nselectable using checkboxes.",
+              "description": "checkboxSelection: Boolean indicating whether rows should be\nselectable using checkboxes.",
               "attribute": "checkboxSelection"
             },
             {
@@ -11694,7 +11666,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "striped: Boolean indicating whether rows should have alternate\r\ncoloring.",
+              "description": "striped: Boolean indicating whether rows should have alternate\ncoloring.",
               "attribute": "striped"
             },
             {
@@ -11710,7 +11682,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "stickyHeader: Boolean indicating whether the table header\r\nshould be sticky.",
+              "description": "stickyHeader: Boolean indicating whether the table header\nshould be sticky.",
               "attribute": "stickyHeader"
             },
             {
@@ -11720,7 +11692,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "dense: Boolean indicating whether the table should be displayed\r\nin dense mode.",
+              "description": "dense: Boolean indicating whether the table should be displayed\nin dense mode.",
               "attribute": "dense"
             },
             {
@@ -11729,8 +11701,8 @@
               "type": {
                 "text": "object"
               },
-              "default": "{\r\n    count: 0,\r\n    pageSize: 5,\r\n    pageNumber: 0,\r\n    pageSizeOptions: [5, 10],\r\n  }",
-              "description": "paginationModel: Object holding pagination information such as\r\ncurrent page, page size, etc.",
+              "default": "{\n    count: 0,\n    pageSize: 5,\n    pageNumber: 0,\n    pageSizeOptions: [5, 10],\n  }",
+              "description": "paginationModel: Object holding pagination information such as\ncurrent page, page size, etc.",
               "attribute": "paginationModel"
             },
             {
@@ -11776,7 +11748,7 @@
             {
               "kind": "method",
               "name": "updateHeaderCheckbox",
-              "description": "Updates the state of the header checkbox based on the number of\r\nselected rows."
+              "description": "Updates the state of the header checkbox based on the number of\nselected rows."
             },
             {
               "kind": "method",
@@ -11865,7 +11837,7 @@
                 "text": "ColumnDefinition[]"
               },
               "default": "[]",
-              "description": "columns: Array of objects defining column properties such as\r\nfield name, sorting function, etc.",
+              "description": "columns: Array of objects defining column properties such as\nfield name, sorting function, etc.",
               "fieldName": "columns"
             },
             {
@@ -11874,7 +11846,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "checkboxSelection: Boolean indicating whether rows should be\r\nselectable using checkboxes.",
+              "description": "checkboxSelection: Boolean indicating whether rows should be\nselectable using checkboxes.",
               "fieldName": "checkboxSelection"
             },
             {
@@ -11883,7 +11855,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "striped: Boolean indicating whether rows should have alternate\r\ncoloring.",
+              "description": "striped: Boolean indicating whether rows should have alternate\ncoloring.",
               "fieldName": "striped"
             },
             {
@@ -11892,7 +11864,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "stickyHeader: Boolean indicating whether the table header\r\nshould be sticky.",
+              "description": "stickyHeader: Boolean indicating whether the table header\nshould be sticky.",
               "fieldName": "stickyHeader"
             },
             {
@@ -11901,7 +11873,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "dense: Boolean indicating whether the table should be displayed\r\nin dense mode.",
+              "description": "dense: Boolean indicating whether the table should be displayed\nin dense mode.",
               "fieldName": "dense"
             },
             {
@@ -11909,8 +11881,8 @@
               "type": {
                 "text": "object"
               },
-              "default": "{\r\n    count: 0,\r\n    pageSize: 5,\r\n    pageNumber: 0,\r\n    pageSizeOptions: [5, 10],\r\n  }",
-              "description": "paginationModel: Object holding pagination information such as\r\ncurrent page, page size, etc.",
+              "default": "{\n    count: 0,\n    pageSize: 5,\n    pageNumber: 0,\n    pageSizeOptions: [5, 10],\n  }",
+              "description": "paginationModel: Object holding pagination information such as\ncurrent page, page size, etc.",
               "fieldName": "paginationModel"
             },
             {
@@ -12108,7 +12080,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-tbody` Web Component.\r\n\r\nRepresents the body section of Shidoka's design system tables. Designed to provide\r\na consistent look and feel, and can offer striped rows for enhanced readability.",
+          "description": "`kyn-tbody` Web Component.\n\nRepresents the body section of Shidoka's design system tables. Designed to provide\na consistent look and feel, and can offer striped rows for enhanced readability.",
           "name": "TableBody",
           "slots": [
             {
@@ -12196,7 +12168,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-td` Web Component.\r\n\r\nRepresents a table cell (data cell) within Shidoka's design system tables.\r\nAllows customization of alignment and can reflect the sort direction when\r\nused within sortable columns.",
+          "description": "`kyn-td` Web Component.\n\nRepresents a table cell (data cell) within Shidoka's design system tables.\nAllows customization of alignment and can reflect the sort direction when\nused within sortable columns.",
           "name": "TableCell",
           "slots": [
             {
@@ -12232,7 +12204,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a fixed width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a fixed width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "width",
               "reflects": true
             },
@@ -12243,7 +12215,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a maximum width for the cell; contents exceeding this limit will be truncated with ellipsis.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a maximum width for the cell; contents exceeding this limit will be truncated with ellipsis.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "maxWidth",
               "reflects": true
             },
@@ -12254,7 +12226,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a minimum width for the cell;\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a minimum width for the cell;\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "minWidth",
               "reflects": true
             },
@@ -12318,7 +12290,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a fixed width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a fixed width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "width"
             },
             {
@@ -12327,7 +12299,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a maximum width for the cell; contents exceeding this limit will be truncated with ellipsis.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a maximum width for the cell; contents exceeding this limit will be truncated with ellipsis.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "maxWidth"
             },
             {
@@ -12336,7 +12308,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a minimum width for the cell;\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a minimum width for the cell;\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "minWidth"
             },
             {
@@ -12391,7 +12363,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-table-container` Web Component.\r\n\r\nProvides a container for Shidoka's design system tables. It's designed to encapsulate\r\nand apply styles uniformly across the table elements.",
+          "description": "`kyn-table-container` Web Component.\n\nProvides a container for Shidoka's design system tables. It's designed to encapsulate\nand apply styles uniformly across the table elements.",
           "name": "TableContainer",
           "slots": [
             {
@@ -12474,7 +12446,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "\r\n`kyn-expanded-tr` Web Component.\r\n\r\nDesigned to display additional details for a row in a table.\r\nThe row is expandable and can be expanded/collapsed by toggling the plus/minus icons.",
+          "description": "\n`kyn-expanded-tr` Web Component.\n\nDesigned to display additional details for a row in a table.\nThe row is expandable and can be expanded/collapsed by toggling the plus/minus icons.",
           "name": "TableExpandedRow",
           "slots": [
             {
@@ -12490,7 +12462,7 @@
                 "text": "number"
               },
               "default": "1",
-              "description": "The number of columns that the expanded row should span.\r\nReflects the `colspan` attribute.",
+              "description": "The number of columns that the expanded row should span.\nReflects the `colspan` attribute.",
               "attribute": "colspan"
             },
             {
@@ -12512,7 +12484,7 @@
                 "text": "number"
               },
               "default": "1",
-              "description": "The number of columns that the expanded row should span.\r\nReflects the `colspan` attribute.",
+              "description": "The number of columns that the expanded row should span.\nReflects the `colspan` attribute.",
               "fieldName": "colSpan"
             },
             {
@@ -12558,7 +12530,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-tfoot` Web Component.\r\n\r\nRepresents a custom table foot (`<tfoot>`) for Shidoka's design system tables.\r\nDesigned to contain and style table footer rows (`<tr>`) and footer cells (`<td>`).",
+          "description": "`kyn-tfoot` Web Component.\n\nRepresents a custom table foot (`<tfoot>`) for Shidoka's design system tables.\nDesigned to contain and style table footer rows (`<tr>`) and footer cells (`<td>`).",
           "name": "TableFoot",
           "slots": [
             {
@@ -12600,7 +12572,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "Table Footer\r\n\r\nIntended to contain Legend and Pagination.",
+          "description": "Table Footer\n\nIntended to contain Legend and Pagination.",
           "name": "TableFooter",
           "slots": [
             {
@@ -12642,7 +12614,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-thead` Web Component.\r\n\r\nRepresents a custom table head (`<thead>`) for Shidoka's design system tables.\r\nDesigned to contain and style table header rows (`<tr>`) and header cells (`<th>`).",
+          "description": "`kyn-thead` Web Component.\n\nRepresents a custom table head (`<thead>`) for Shidoka's design system tables.\nDesigned to contain and style table header rows (`<tr>`) and header cells (`<th>`).",
           "name": "TableHead",
           "slots": [
             {
@@ -12732,7 +12704,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-header-tr` Web Component.\r\n\r\nThe `<kyn-header-tr>` component is designed to function as the\r\nheader row within a table that's part of Shidoka's design system.",
+          "description": "`kyn-header-tr` Web Component.\n\nThe `<kyn-header-tr>` component is designed to function as the\nheader row within a table that's part of Shidoka's design system.",
           "name": "TableHeaderRow",
           "members": [
             {
@@ -12785,7 +12757,7 @@
                   }
                 }
               ],
-              "description": "Updates the state of the header checkbox based on the number of\r\nselected rows."
+              "description": "Updates the state of the header checkbox based on the number of\nselected rows."
             },
             {
               "kind": "field",
@@ -12809,7 +12781,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "selected: Boolean indicating whether the row is selected.\r\nReflects the `selected` attribute.",
+              "description": "selected: Boolean indicating whether the row is selected.\nReflects the `selected` attribute.",
               "attribute": "selected",
               "reflects": true,
               "inheritedFrom": {
@@ -12824,7 +12796,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "checkboxSelection: Boolean indicating whether rows should be\r\nselectable using checkboxes.",
+              "description": "checkboxSelection: Boolean indicating whether rows should be\nselectable using checkboxes.",
               "attribute": "checkboxSelection",
               "reflects": true,
               "inheritedFrom": {
@@ -12839,7 +12811,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "dense: Boolean indicating whether the table should be displayed\r\nin dense mode.",
+              "description": "dense: Boolean indicating whether the table should be displayed\nin dense mode.",
               "attribute": "dense",
               "inheritedFrom": {
                 "name": "TableRow",
@@ -12867,7 +12839,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "locked: Boolean indicating whether the row is locked.\r\nIf a row is selected before it is locked, it remains selected even after being locked.\r\nA row can be selected and disabled/locked simultaneously.",
+              "description": "locked: Boolean indicating whether the row is locked.\nIf a row is selected before it is locked, it remains selected even after being locked.\nA row can be selected and disabled/locked simultaneously.",
               "attribute": "locked",
               "reflects": true,
               "inheritedFrom": {
@@ -12912,7 +12884,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "disabled: Boolean indicating whether the row is disabled.\r\nA disabled row is not allowed to have any user interactions.\r\nA row can be selected and disabled/locked simultaneously.",
+              "description": "disabled: Boolean indicating whether the row is disabled.\nA disabled row is not allowed to have any user interactions.\nA row can be selected and disabled/locked simultaneously.",
               "attribute": "disabled",
               "reflects": true,
               "inheritedFrom": {
@@ -12942,7 +12914,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "dimmed: Boolean indicating whether the row is dimmed.\r\nA row should not be selected and dimmed simultaneously.",
+              "description": "dimmed: Boolean indicating whether the row is dimmed.\nA row should not be selected and dimmed simultaneously.",
               "attribute": "dimmed",
               "reflects": true,
               "inheritedFrom": {
@@ -13085,7 +13057,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "selected: Boolean indicating whether the row is selected.\r\nReflects the `selected` attribute.",
+              "description": "selected: Boolean indicating whether the row is selected.\nReflects the `selected` attribute.",
               "fieldName": "selected",
               "inheritedFrom": {
                 "name": "TableRow",
@@ -13098,7 +13070,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "checkboxSelection: Boolean indicating whether rows should be\r\nselectable using checkboxes.",
+              "description": "checkboxSelection: Boolean indicating whether rows should be\nselectable using checkboxes.",
               "fieldName": "checkboxSelection",
               "inheritedFrom": {
                 "name": "TableRow",
@@ -13111,7 +13083,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "dense: Boolean indicating whether the table should be displayed\r\nin dense mode.",
+              "description": "dense: Boolean indicating whether the table should be displayed\nin dense mode.",
               "fieldName": "dense",
               "inheritedFrom": {
                 "name": "TableRow",
@@ -13137,7 +13109,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "locked: Boolean indicating whether the row is locked.\r\nIf a row is selected before it is locked, it remains selected even after being locked.\r\nA row can be selected and disabled/locked simultaneously.",
+              "description": "locked: Boolean indicating whether the row is locked.\nIf a row is selected before it is locked, it remains selected even after being locked.\nA row can be selected and disabled/locked simultaneously.",
               "fieldName": "locked",
               "inheritedFrom": {
                 "name": "TableRow",
@@ -13176,7 +13148,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "disabled: Boolean indicating whether the row is disabled.\r\nA disabled row is not allowed to have any user interactions.\r\nA row can be selected and disabled/locked simultaneously.",
+              "description": "disabled: Boolean indicating whether the row is disabled.\nA disabled row is not allowed to have any user interactions.\nA row can be selected and disabled/locked simultaneously.",
               "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "TableRow",
@@ -13202,7 +13174,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "dimmed: Boolean indicating whether the row is dimmed.\r\nA row should not be selected and dimmed simultaneously.",
+              "description": "dimmed: Boolean indicating whether the row is dimmed.\nA row should not be selected and dimmed simultaneously.",
               "fieldName": "dimmed",
               "inheritedFrom": {
                 "name": "TableRow",
@@ -13253,7 +13225,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-th` Web Component.\r\n\r\nRepresents a custom table header cell (`<th>`) for Shidoka's design system tables.\r\nProvides sorting functionality when enabled and allows alignment customization.",
+          "description": "`kyn-th` Web Component.\n\nRepresents a custom table header cell (`<th>`) for Shidoka's design system tables.\nProvides sorting functionality when enabled and allows alignment customization.",
           "name": "TableHeader",
           "slots": [
             {
@@ -13293,7 +13265,7 @@
               "type": {
                 "text": "TABLE_CELL_ALIGN"
               },
-              "description": "Specifies the alignment of the content within the table header.\r\nOptions: 'left', 'center', 'right'",
+              "description": "Specifies the alignment of the content within the table header.\nOptions: 'left', 'center', 'right'",
               "attribute": "align",
               "reflects": true
             },
@@ -13304,7 +13276,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Specifies if the column is sortable.\r\nIf set to true, an arrow icon will be displayed unpon hover,\r\nallowing the user to toggle sort directions.",
+              "description": "Specifies if the column is sortable.\nIf set to true, an arrow icon will be displayed unpon hover,\nallowing the user to toggle sort directions.",
               "attribute": "sortable",
               "reflects": true
             },
@@ -13325,7 +13297,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The textual content associated with this component.\r\nRepresents the primary content or label that will be displayed.",
+              "description": "The textual content associated with this component.\nRepresents the primary content or label that will be displayed.",
               "attribute": "headerLabel"
             },
             {
@@ -13335,7 +13307,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The unique identifier representing this column header.\r\nUsed to distinguish between different sortable columns and\r\nto ensure that only one column is sorted at a time.",
+              "description": "The unique identifier representing this column header.\nUsed to distinguish between different sortable columns and\nto ensure that only one column is sorted at a time.",
               "attribute": "sortKey"
             },
             {
@@ -13345,7 +13317,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Determines whether the content should be hidden from visual view but remain accessible\r\nto screen readers for accessibility purposes. When set to `true`, the content\r\nwill not be visibly shown, but its content can still be read by screen readers.\r\nThis is especially useful for providing additional context or information to\r\nassistive technologies without cluttering the visual UI.",
+              "description": "Determines whether the content should be hidden from visual view but remain accessible\nto screen readers for accessibility purposes. When set to `true`, the content\nwill not be visibly shown, but its content can still be read by screen readers.\nThis is especially useful for providing additional context or information to\nassistive technologies without cluttering the visual UI.",
               "attribute": "visiblyHidden"
             },
             {
@@ -13355,7 +13327,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a fixed width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a fixed width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "width",
               "reflects": true
             },
@@ -13366,7 +13338,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a maximum width for the cell; contents exceeding this limit will be truncated with ellipsis.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a maximum width for the cell; contents exceeding this limit will be truncated with ellipsis.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "maxWidth",
               "reflects": true
             },
@@ -13377,20 +13349,20 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a minimum width for the cell;\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a minimum width for the cell;\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "minWidth",
               "reflects": true
             },
             {
               "kind": "method",
               "name": "resetSort",
-              "description": "Resets the sorting direction of the component to its default state.\r\nUseful for initializing or clearing any applied sorting on the element."
+              "description": "Resets the sorting direction of the component to its default state.\nUseful for initializing or clearing any applied sorting on the element."
             },
             {
               "kind": "method",
               "name": "toggleSortDirection",
               "privacy": "private",
-              "description": "Toggles the sort direction between ascending, descending, and default states.\r\nIt also dispatches an event to notify parent components of the sorting change."
+              "description": "Toggles the sort direction between ascending, descending, and default states.\nIt also dispatches an event to notify parent components of the sorting change."
             },
             {
               "kind": "method",
@@ -13421,7 +13393,7 @@
               "type": {
                 "text": "TABLE_CELL_ALIGN"
               },
-              "description": "Specifies the alignment of the content within the table header.\r\nOptions: 'left', 'center', 'right'",
+              "description": "Specifies the alignment of the content within the table header.\nOptions: 'left', 'center', 'right'",
               "fieldName": "align"
             },
             {
@@ -13430,7 +13402,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Specifies if the column is sortable.\r\nIf set to true, an arrow icon will be displayed unpon hover,\r\nallowing the user to toggle sort directions.",
+              "description": "Specifies if the column is sortable.\nIf set to true, an arrow icon will be displayed unpon hover,\nallowing the user to toggle sort directions.",
               "fieldName": "sortable"
             },
             {
@@ -13447,7 +13419,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The textual content associated with this component.\r\nRepresents the primary content or label that will be displayed.",
+              "description": "The textual content associated with this component.\nRepresents the primary content or label that will be displayed.",
               "fieldName": "headerLabel"
             },
             {
@@ -13456,7 +13428,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The unique identifier representing this column header.\r\nUsed to distinguish between different sortable columns and\r\nto ensure that only one column is sorted at a time.",
+              "description": "The unique identifier representing this column header.\nUsed to distinguish between different sortable columns and\nto ensure that only one column is sorted at a time.",
               "fieldName": "sortKey"
             },
             {
@@ -13465,7 +13437,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Determines whether the content should be hidden from visual view but remain accessible\r\nto screen readers for accessibility purposes. When set to `true`, the content\r\nwill not be visibly shown, but its content can still be read by screen readers.\r\nThis is especially useful for providing additional context or information to\r\nassistive technologies without cluttering the visual UI.",
+              "description": "Determines whether the content should be hidden from visual view but remain accessible\nto screen readers for accessibility purposes. When set to `true`, the content\nwill not be visibly shown, but its content can still be read by screen readers.\nThis is especially useful for providing additional context or information to\nassistive technologies without cluttering the visual UI.",
               "fieldName": "visiblyHidden"
             },
             {
@@ -13474,7 +13446,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a fixed width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a fixed width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "width"
             },
             {
@@ -13483,7 +13455,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a maximum width for the cell; contents exceeding this limit will be truncated with ellipsis.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a maximum width for the cell; contents exceeding this limit will be truncated with ellipsis.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "maxWidth"
             },
             {
@@ -13492,7 +13464,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a minimum width for the cell;\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a minimum width for the cell;\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "minWidth"
             }
           ],
@@ -13613,7 +13585,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-tr` Web Component.\r\n\r\nRepresents a table row (`<tr>`) equivalent for custom tables created with Shidoka's design system.\r\nIt primarily acts as a container for individual table cells and behaves similarly to a native `<tr>` element.",
+          "description": "`kyn-tr` Web Component.\n\nRepresents a table row (`<tr>`) equivalent for custom tables created with Shidoka's design system.\nIt primarily acts as a container for individual table cells and behaves similarly to a native `<tr>` element.",
           "name": "TableRow",
           "slots": [
             {
@@ -13640,7 +13612,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "selected: Boolean indicating whether the row is selected.\r\nReflects the `selected` attribute.",
+              "description": "selected: Boolean indicating whether the row is selected.\nReflects the `selected` attribute.",
               "attribute": "selected",
               "reflects": true
             },
@@ -13651,7 +13623,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "checkboxSelection: Boolean indicating whether rows should be\r\nselectable using checkboxes.",
+              "description": "checkboxSelection: Boolean indicating whether rows should be\nselectable using checkboxes.",
               "attribute": "checkboxSelection",
               "reflects": true
             },
@@ -13662,7 +13634,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "dense: Boolean indicating whether the table should be displayed\r\nin dense mode.",
+              "description": "dense: Boolean indicating whether the table should be displayed\nin dense mode.",
               "attribute": "dense"
             },
             {
@@ -13682,7 +13654,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "locked: Boolean indicating whether the row is locked.\r\nIf a row is selected before it is locked, it remains selected even after being locked.\r\nA row can be selected and disabled/locked simultaneously.",
+              "description": "locked: Boolean indicating whether the row is locked.\nIf a row is selected before it is locked, it remains selected even after being locked.\nA row can be selected and disabled/locked simultaneously.",
               "attribute": "locked",
               "reflects": true
             },
@@ -13715,7 +13687,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "disabled: Boolean indicating whether the row is disabled.\r\nA disabled row is not allowed to have any user interactions.\r\nA row can be selected and disabled/locked simultaneously.",
+              "description": "disabled: Boolean indicating whether the row is disabled.\nA disabled row is not allowed to have any user interactions.\nA row can be selected and disabled/locked simultaneously.",
               "attribute": "disabled",
               "reflects": true
             },
@@ -13737,7 +13709,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "dimmed: Boolean indicating whether the row is dimmed.\r\nA row should not be selected and dimmed simultaneously.",
+              "description": "dimmed: Boolean indicating whether the row is dimmed.\nA row should not be selected and dimmed simultaneously.",
               "attribute": "dimmed",
               "reflects": true
             },
@@ -13820,7 +13792,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "selected: Boolean indicating whether the row is selected.\r\nReflects the `selected` attribute.",
+              "description": "selected: Boolean indicating whether the row is selected.\nReflects the `selected` attribute.",
               "fieldName": "selected"
             },
             {
@@ -13829,7 +13801,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "checkboxSelection: Boolean indicating whether rows should be\r\nselectable using checkboxes.",
+              "description": "checkboxSelection: Boolean indicating whether rows should be\nselectable using checkboxes.",
               "fieldName": "checkboxSelection"
             },
             {
@@ -13838,7 +13810,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "dense: Boolean indicating whether the table should be displayed\r\nin dense mode.",
+              "description": "dense: Boolean indicating whether the table should be displayed\nin dense mode.",
               "fieldName": "dense"
             },
             {
@@ -13856,7 +13828,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "locked: Boolean indicating whether the row is locked.\r\nIf a row is selected before it is locked, it remains selected even after being locked.\r\nA row can be selected and disabled/locked simultaneously.",
+              "description": "locked: Boolean indicating whether the row is locked.\nIf a row is selected before it is locked, it remains selected even after being locked.\nA row can be selected and disabled/locked simultaneously.",
               "fieldName": "locked"
             },
             {
@@ -13883,7 +13855,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "disabled: Boolean indicating whether the row is disabled.\r\nA disabled row is not allowed to have any user interactions.\r\nA row can be selected and disabled/locked simultaneously.",
+              "description": "disabled: Boolean indicating whether the row is disabled.\nA disabled row is not allowed to have any user interactions.\nA row can be selected and disabled/locked simultaneously.",
               "fieldName": "disabled"
             },
             {
@@ -13901,7 +13873,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "dimmed: Boolean indicating whether the row is dimmed.\r\nA row should not be selected and dimmed simultaneously.",
+              "description": "dimmed: Boolean indicating whether the row is dimmed.\nA row should not be selected and dimmed simultaneously.",
               "fieldName": "dimmed"
             }
           ],
@@ -13938,7 +13910,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-table-toolbar` Web Component.\r\n\r\nThis component provides a toolbar for tables, primarily featuring a title and additional content.\r\nThe title is rendered prominently, while the slot can be used for controls, buttons, or other interactive elements.",
+          "description": "`kyn-table-toolbar` Web Component.\n\nThis component provides a toolbar for tables, primarily featuring a title and additional content.\nThe title is rendered prominently, while the slot can be used for controls, buttons, or other interactive elements.",
           "name": "TableToolbar",
           "slots": [
             {
@@ -14021,7 +13993,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-table` Web Component.\r\nThis component provides a table with sorting, pagination, and selection capabilities.\r\nIt is designed to be used with the `kyn-table-toolbar` and `kyn-table-container` components.",
+          "description": "`kyn-table` Web Component.\nThis component provides a table with sorting, pagination, and selection capabilities.\nIt is designed to be used with the `kyn-table-toolbar` and `kyn-table-container` components.",
           "name": "Table",
           "members": [
             {
@@ -14030,7 +14002,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "checkboxSelection: Boolean indicating whether rows should be\r\nselectable using checkboxes.",
+              "description": "checkboxSelection: Boolean indicating whether rows should be\nselectable using checkboxes.",
               "default": "false",
               "attribute": "checkboxSelection"
             },
@@ -14040,7 +14012,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "striped: Boolean indicating whether rows should have alternate\r\ncoloring.",
+              "description": "striped: Boolean indicating whether rows should have alternate\ncoloring.",
               "default": "false",
               "attribute": "striped"
             },
@@ -14050,7 +14022,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "stickyHeader: Boolean indicating whether the table header\r\nshould be sticky.",
+              "description": "stickyHeader: Boolean indicating whether the table header\nshould be sticky.",
               "default": "false",
               "attribute": "stickyHeader"
             },
@@ -14060,7 +14032,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "dense: Boolean indicating whether the table should be displayed\r\nin dense mode.",
+              "description": "dense: Boolean indicating whether the table should be displayed\nin dense mode.",
               "default": "false",
               "attribute": "dense"
             },
@@ -14070,7 +14042,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "fixedLayout: Boolean indicating whether the table should have a fixed layout.\r\nThis will set the table's layout to fixed, which means the table and column widths\r\nwill be determined by the width of the columns and not by the content of the cells.\r\nThis can be useful when you want to have a consistent column width across multiple tables.",
+              "description": "fixedLayout: Boolean indicating whether the table should have a fixed layout.\nThis will set the table's layout to fixed, which means the table and column widths\nwill be determined by the width of the columns and not by the content of the cells.\nThis can be useful when you want to have a consistent column width across multiple tables.",
               "default": "false",
               "attribute": "fixedLayout"
             },
@@ -14078,7 +14050,7 @@
               "kind": "method",
               "name": "_updateHeaderCheckbox",
               "privacy": "private",
-              "description": "Updates the state of the header checkbox based on the number of\r\nselected rows."
+              "description": "Updates the state of the header checkbox based on the number of\nselected rows."
             },
             {
               "kind": "method",
@@ -14112,7 +14084,7 @@
               "kind": "method",
               "name": "updateAfterExternalChanges",
               "privacy": "public",
-              "description": "Resets the selection state of all rows in the table.\r\nThis method is called when the table is reset or cleared.",
+              "description": "Resets the selection state of all rows in the table.\nThis method is called when the table is reset or cleared.",
               "return": {
                 "type": {
                   "text": ""
@@ -14173,7 +14145,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "checkboxSelection: Boolean indicating whether rows should be\r\nselectable using checkboxes.",
+              "description": "checkboxSelection: Boolean indicating whether rows should be\nselectable using checkboxes.",
               "default": "false",
               "fieldName": "checkboxSelection"
             },
@@ -14182,7 +14154,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "striped: Boolean indicating whether rows should have alternate\r\ncoloring.",
+              "description": "striped: Boolean indicating whether rows should have alternate\ncoloring.",
               "default": "false",
               "fieldName": "striped"
             },
@@ -14191,7 +14163,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "stickyHeader: Boolean indicating whether the table header\r\nshould be sticky.",
+              "description": "stickyHeader: Boolean indicating whether the table header\nshould be sticky.",
               "default": "false",
               "fieldName": "stickyHeader"
             },
@@ -14200,7 +14172,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "dense: Boolean indicating whether the table should be displayed\r\nin dense mode.",
+              "description": "dense: Boolean indicating whether the table should be displayed\nin dense mode.",
               "default": "false",
               "fieldName": "dense"
             },
@@ -14209,7 +14181,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "fixedLayout: Boolean indicating whether the table should have a fixed layout.\r\nThis will set the table's layout to fixed, which means the table and column widths\r\nwill be determined by the width of the columns and not by the content of the cells.\r\nThis can be useful when you want to have a consistent column width across multiple tables.",
+              "description": "fixedLayout: Boolean indicating whether the table should have a fixed layout.\nThis will set the table's layout to fixed, which means the table and column widths\nwill be determined by the width of the columns and not by the content of the cells.\nThis can be useful when you want to have a consistent column width across multiple tables.",
               "default": "false",
               "fieldName": "fixedLayout"
             }
@@ -14329,10 +14301,10 @@
                   "type": {
                     "text": "any"
                   },
-                  "description": "The parameter \"e\" is an event object that represents the event that triggered the\r\nclick event handler."
+                  "description": "The parameter \"e\" is an event object that represents the event that triggered the\nclick event handler."
                 }
               ],
-              "description": "Dispatches a custom event called 'tab-activated' with the original event and tabId as details,\r\nif the tab is not selected."
+              "description": "Dispatches a custom event called 'tab-activated' with the original event and tabId as details,\nif the tab is not selected."
             }
           ],
           "attributes": [
@@ -14563,10 +14535,10 @@
                   "type": {
                     "text": "any"
                   },
-                  "description": "The parameter \"e\" is an event object that contains information about the event\r\nthat triggered the handleChange function."
+                  "description": "The parameter \"e\" is an event object that contains information about the event\nthat triggered the handleChange function."
                 }
               ],
-              "description": "Updates children and emits a change event based on the provided\r\nevent details when a child kyn-tab is clicked."
+              "description": "Updates children and emits a change event based on the provided\nevent details when a child kyn-tab is clicked."
             },
             {
               "kind": "method",
@@ -14578,10 +14550,10 @@
                   "type": {
                     "text": "string"
                   },
-                  "description": "The selectedTabId parameter is a string that represents the ID of\r\nthe tab that is currently selected."
+                  "description": "The selectedTabId parameter is a string that represents the ID of\nthe tab that is currently selected."
                 }
               ],
-              "description": "Updates the selected property of tabs and the visible property of tab panels based on\r\nthe selected tab ID."
+              "description": "Updates the selected property of tabs and the visible property of tab panels based on\nthe selected tab ID."
             },
             {
               "kind": "method",
@@ -14593,17 +14565,17 @@
                   "type": {
                     "text": "any"
                   },
-                  "description": "The origEvent parameter is the original event object that triggered the\r\nchange event. It could be any type of event object, such as a click event or a keydown event."
+                  "description": "The origEvent parameter is the original event object that triggered the\nchange event. It could be any type of event object, such as a click event or a keydown event."
                 },
                 {
                   "name": "selectedTabId",
                   "type": {
                     "text": "string"
                   },
-                  "description": "The selectedTabId parameter is a string that represents the ID of\r\nthe selected tab."
+                  "description": "The selectedTabId parameter is a string that represents the ID of\nthe selected tab."
                 }
               ],
-              "description": "Creates and dispatches a custom event called 'on-change' with the provided original event and\r\nselected tab ID as details."
+              "description": "Creates and dispatches a custom event called 'on-change' with the provided original event and\nselected tab ID as details."
             },
             {
               "kind": "method",
@@ -14615,7 +14587,7 @@
                   "type": {
                     "text": "any"
                   },
-                  "description": "The parameter `e` is an event object that represents the keyboard event. It\r\ncontains information about the keyboard event, such as the key code of the pressed key."
+                  "description": "The parameter `e` is an event object that represents the keyboard event. It\ncontains information about the keyboard event, such as the key code of the pressed key."
                 }
               ],
               "description": "Handles keyboard events for navigating between tabs.",
@@ -14929,7 +14901,7 @@
               "type": {
                 "text": "object"
               },
-              "default": "{\r\n    showAll: 'Show all',\r\n    showLess: 'Show less',\r\n  }",
+              "default": "{\n    showAll: 'Show all',\n    showLess: 'Show less',\n  }",
               "description": "Text string customization.",
               "attribute": "textStrings"
             },
@@ -14993,7 +14965,7 @@
               "type": {
                 "text": "object"
               },
-              "default": "{\r\n    showAll: 'Show all',\r\n    showLess: 'Show less',\r\n  }",
+              "default": "{\n    showAll: 'Show all',\n    showLess: 'Show less',\n  }",
               "description": "Text string customization.",
               "fieldName": "textStrings"
             },
@@ -15228,16 +15200,6 @@
               "default": "''",
               "description": "Input invalid text.",
               "attribute": "invalidText",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_handleInvalid",
-              "privacy": "private",
-              "description": "Handles the invalid event, triggered on form submit, and runs validation.",
               "inheritedFrom": {
                 "name": "FormMixin",
                 "module": "src/common/mixins/form-input.ts"
@@ -15582,7 +15544,7 @@
               "type": {
                 "text": "object"
               },
-              "default": "{\r\n    clearAll: 'Clear all',\r\n  }",
+              "default": "{\n    clearAll: 'Clear all',\n  }",
               "description": "Customizable text strings.",
               "attribute": "textStrings"
             },
@@ -15689,16 +15651,6 @@
               "default": "''",
               "description": "Input invalid text.",
               "attribute": "invalidText",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_handleInvalid",
-              "privacy": "private",
-              "description": "Handles the invalid event, triggered on form submit, and runs validation.",
               "inheritedFrom": {
                 "name": "FormMixin",
                 "module": "src/common/mixins/form-input.ts"
@@ -15864,7 +15816,7 @@
               "type": {
                 "text": "object"
               },
-              "default": "{\r\n    clearAll: 'Clear all',\r\n  }",
+              "default": "{\n    clearAll: 'Clear all',\n  }",
               "description": "Customizable text strings.",
               "fieldName": "textStrings"
             },
@@ -15998,7 +15950,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The value of the time input is always in 24-hour format that includes leading zeros: hh:mm,\r\nregardless of the input format, which is likely to be selected based on the user's locale (or by the user agent).\r\nIf the time includes seconds (by step attribute), the format is always hh:mm:ss",
+              "description": "The value of the time input is always in 24-hour format that includes leading zeros: hh:mm,\nregardless of the input format, which is likely to be selected based on the user's locale (or by the user agent).\nIf the time includes seconds (by step attribute), the format is always hh:mm:ss",
               "attribute": "value",
               "inheritedFrom": {
                 "name": "FormMixin",
@@ -16059,7 +16011,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Specifies the granularity that the value must adhere to, or the special value any,\r\nIt takes value that equates to the number of seconds you want to increment by;\r\nthe default (60 sec.). If you specify a value of less than 60 sec., the time input will show a seconds input area alongside the hours and minutes",
+              "description": "Specifies the granularity that the value must adhere to, or the special value any,\nIt takes value that equates to the number of seconds you want to increment by;\nthe default (60 sec.). If you specify a value of less than 60 sec., the time input will show a seconds input area alongside the hours and minutes",
               "attribute": "step"
             },
             {
@@ -16127,16 +16079,6 @@
               "default": "''",
               "description": "Input invalid text.",
               "attribute": "invalidText",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_handleInvalid",
-              "privacy": "private",
-              "description": "Handles the invalid event, triggered on form submit, and runs validation.",
               "inheritedFrom": {
                 "name": "FormMixin",
                 "module": "src/common/mixins/form-input.ts"
@@ -16225,7 +16167,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The value of the time input is always in 24-hour format that includes leading zeros: hh:mm,\r\nregardless of the input format, which is likely to be selected based on the user's locale (or by the user agent).\r\nIf the time includes seconds (by step attribute), the format is always hh:mm:ss",
+              "description": "The value of the time input is always in 24-hour format that includes leading zeros: hh:mm,\nregardless of the input format, which is likely to be selected based on the user's locale (or by the user agent).\nIf the time includes seconds (by step attribute), the format is always hh:mm:ss",
               "fieldName": "value",
               "inheritedFrom": {
                 "name": "FormMixin",
@@ -16280,7 +16222,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Specifies the granularity that the value must adhere to, or the special value any,\r\nIt takes value that equates to the number of seconds you want to increment by;\r\nthe default (60 sec.). If you specify a value of less than 60 sec., the time input will show a seconds input area alongside the hours and minutes",
+              "description": "Specifies the granularity that the value must adhere to, or the special value any,\nIt takes value that equates to the number of seconds you want to increment by;\nthe default (60 sec.). If you specify a value of less than 60 sec., the time input will show a seconds input area alongside the hours and minutes",
               "fieldName": "step"
             },
             {
@@ -16522,16 +16464,6 @@
               "default": "''",
               "description": "Input invalid text.",
               "attribute": "invalidText",
-              "inheritedFrom": {
-                "name": "FormMixin",
-                "module": "src/common/mixins/form-input.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_handleInvalid",
-              "privacy": "private",
-              "description": "Handles the invalid event, triggered on form submit, and runs validation.",
               "inheritedFrom": {
                 "name": "FormMixin",
                 "module": "src/common/mixins/form-input.ts"
@@ -18120,7 +18052,7 @@
               "type": {
                 "text": "any"
               },
-              "default": "[\r\n    {\r\n      id: 'col1',\r\n      order: 1,\r\n      colName: 'COLUMN 1',\r\n      locked: true,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col2',\r\n      order: 2,\r\n      colName: 'COLUMN 2',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col3',\r\n      order: 3,\r\n      colName: 'COLUMN 3',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col4',\r\n      order: 4,\r\n      colName: 'COLUMN 4',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col5',\r\n      order: 5,\r\n      colName: 'COLUMN 5',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col6',\r\n      order: 6,\r\n      colName: 'COLUMN 6',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col7',\r\n      order: 7,\r\n      colName: 'COLUMN 7',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col8',\r\n      order: 8,\r\n      colName: 'COLUMN 8',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col9',\r\n      order: 9,\r\n      colName: 'COLUMN 9',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col10',\r\n      order: 10,\r\n      colName: 'COLUMN 10',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col11',\r\n      order: 11,\r\n      colName: 'COLUMN 11',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col12',\r\n      order: 12,\r\n      colName: 'COLUMN 12',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col13',\r\n      order: 13,\r\n      colName: 'COLUMN 13',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col14',\r\n      order: 14,\r\n      colName: 'COLUMN 14',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col15',\r\n      order: 15,\r\n      colName: 'COLUMN 15',\r\n      locked: false,\r\n      visible: true,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col16',\r\n      order: 16,\r\n      colName: 'COLUMN 16',\r\n      locked: false,\r\n      visible: false,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col17',\r\n      order: 17,\r\n      colName: 'COLUMN 17',\r\n      locked: false,\r\n      visible: false,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col18',\r\n      order: 18,\r\n      colName: 'COLUMN 18',\r\n      locked: false,\r\n      visible: false,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col19',\r\n      order: 19,\r\n      colName: 'COLUMN 19',\r\n      locked: false,\r\n      visible: false,\r\n      align: 'center',\r\n    },\r\n    {\r\n      id: 'col20',\r\n      order: 20,\r\n      colName: 'COLUMN 20',\r\n      locked: false,\r\n      visible: false,\r\n      align: 'center',\r\n    },\r\n  ]"
+              "default": "[\n    {\n      id: 'col1',\n      order: 1,\n      colName: 'COLUMN 1',\n      locked: true,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col2',\n      order: 2,\n      colName: 'COLUMN 2',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col3',\n      order: 3,\n      colName: 'COLUMN 3',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col4',\n      order: 4,\n      colName: 'COLUMN 4',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col5',\n      order: 5,\n      colName: 'COLUMN 5',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col6',\n      order: 6,\n      colName: 'COLUMN 6',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col7',\n      order: 7,\n      colName: 'COLUMN 7',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col8',\n      order: 8,\n      colName: 'COLUMN 8',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col9',\n      order: 9,\n      colName: 'COLUMN 9',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col10',\n      order: 10,\n      colName: 'COLUMN 10',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col11',\n      order: 11,\n      colName: 'COLUMN 11',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col12',\n      order: 12,\n      colName: 'COLUMN 12',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col13',\n      order: 13,\n      colName: 'COLUMN 13',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col14',\n      order: 14,\n      colName: 'COLUMN 14',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col15',\n      order: 15,\n      colName: 'COLUMN 15',\n      locked: false,\n      visible: true,\n      align: 'center',\n    },\n    {\n      id: 'col16',\n      order: 16,\n      colName: 'COLUMN 16',\n      locked: false,\n      visible: false,\n      align: 'center',\n    },\n    {\n      id: 'col17',\n      order: 17,\n      colName: 'COLUMN 17',\n      locked: false,\n      visible: false,\n      align: 'center',\n    },\n    {\n      id: 'col18',\n      order: 18,\n      colName: 'COLUMN 18',\n      locked: false,\n      visible: false,\n      align: 'center',\n    },\n    {\n      id: 'col19',\n      order: 19,\n      colName: 'COLUMN 19',\n      locked: false,\n      visible: false,\n      align: 'center',\n    },\n    {\n      id: 'col20',\n      order: 20,\n      colName: 'COLUMN 20',\n      locked: false,\n      visible: false,\n      align: 'center',\n    },\n  ]"
             },
             {
               "kind": "method",
@@ -18272,7 +18204,7 @@
           "type": {
             "text": "array"
           },
-          "default": "[\r\n  {\r\n    id: 1,\r\n    firstName: 'Jon',\r\n    lastName: 'Snow',\r\n    age: 23,\r\n    birthday: 'December 26',\r\n    fullname: 'Jon Snow',\r\n    gender: 'Male',\r\n    unread: true,\r\n  },\r\n  {\r\n    id: 2,\r\n    firstName: 'Daenerys',\r\n    lastName: 'Targaryen',\r\n    age: 22,\r\n    birthday: 'April 23',\r\n    fullname: 'Daenerys Targaryen',\r\n    gender: 'Female',\r\n  },\r\n  {\r\n    id: 3,\r\n    firstName: 'Tyrion',\r\n    lastName: 'Lannister',\r\n    age: 39,\r\n    birthday: 'June 12',\r\n    fullname: 'Tyrion Lannister',\r\n    gender: 'Male',\r\n  },\r\n  {\r\n    id: 4,\r\n    firstName: 'Arya',\r\n    lastName: 'Stark',\r\n    age: 18,\r\n    birthday: 'February 15',\r\n    fullname: 'Arya Stark',\r\n    gender: 'Female',\r\n  },\r\n  {\r\n    id: 5,\r\n    firstName: 'Cersei',\r\n    lastName: 'Lannister',\r\n    age: 42,\r\n    birthday: 'November 30',\r\n    fullname: 'Cersei Lannister',\r\n    gender: 'Female',\r\n  },\r\n]"
+          "default": "[\n  {\n    id: 1,\n    firstName: 'Jon',\n    lastName: 'Snow',\n    age: 23,\n    birthday: 'December 26',\n    fullname: 'Jon Snow',\n    gender: 'Male',\n    unread: true,\n  },\n  {\n    id: 2,\n    firstName: 'Daenerys',\n    lastName: 'Targaryen',\n    age: 22,\n    birthday: 'April 23',\n    fullname: 'Daenerys Targaryen',\n    gender: 'Female',\n  },\n  {\n    id: 3,\n    firstName: 'Tyrion',\n    lastName: 'Lannister',\n    age: 39,\n    birthday: 'June 12',\n    fullname: 'Tyrion Lannister',\n    gender: 'Male',\n  },\n  {\n    id: 4,\n    firstName: 'Arya',\n    lastName: 'Stark',\n    age: 18,\n    birthday: 'February 15',\n    fullname: 'Arya Stark',\n    gender: 'Female',\n  },\n  {\n    id: 5,\n    firstName: 'Cersei',\n    lastName: 'Lannister',\n    age: 42,\n    birthday: 'November 30',\n    fullname: 'Cersei Lannister',\n    gender: 'Female',\n  },\n]"
         },
         {
           "kind": "variable",
@@ -18280,7 +18212,7 @@
           "type": {
             "text": "array"
           },
-          "default": "[\r\n  {\r\n    id: 'row1',\r\n    col1: 'Column 1',\r\n    col2: 'Column 2',\r\n    col3: 'Column 3',\r\n    col4: 'Column 4',\r\n    col5: 'Column 5',\r\n    col6: 'Column 6',\r\n    col7: 'Column 7',\r\n    col8: 'Column 8',\r\n    col9: 'Column 9',\r\n    col10: 'Column 10',\r\n    col11: 'Column 11',\r\n    col12: 'Column 12',\r\n    col13: 'Column 13',\r\n    col14: 'Column 14',\r\n    col15: 'Column 15',\r\n    col16: 'Column 16',\r\n    col17: 'Column 17',\r\n    col18: 'Column 18',\r\n    col19: 'Column 19',\r\n    col20: 'Column 20',\r\n  },\r\n  {\r\n    id: 'row2',\r\n    col1: 'Column 1',\r\n    col2: 'Column 2',\r\n    col3: 'Column 3',\r\n    col4: 'Column 4',\r\n    col5: 'Column 5',\r\n    col6: 'Column 6',\r\n    col7: 'Column 7',\r\n    col8: 'Column 8',\r\n    col9: 'Column 9',\r\n    col10: 'Column 10',\r\n    col11: 'Column 11',\r\n    col12: 'Column 12',\r\n    col13: 'Column 13',\r\n    col14: 'Column 14',\r\n    col15: 'Column 15',\r\n    col16: 'Column 16',\r\n    col17: 'Column 17',\r\n    col18: 'Column 18',\r\n    col19: 'Column 19',\r\n    col20: 'Column 20',\r\n  },\r\n  {\r\n    id: 'row3',\r\n    col1: 'Column 1',\r\n    col2: 'Column 2',\r\n    col3: 'Column 3',\r\n    col4: 'Column 4',\r\n    col5: 'Column 5',\r\n    col6: 'Column 6',\r\n    col7: 'Column 7',\r\n    col8: 'Column 8',\r\n    col9: 'Column 9',\r\n    col10: 'Column 10',\r\n    col11: 'Column 11',\r\n    col12: 'Column 12',\r\n    col13: 'Column 13',\r\n    col14: 'Column 14',\r\n    col15: 'Column 15',\r\n    col16: 'Column 16',\r\n    col17: 'Column 17',\r\n    col18: 'Column 18',\r\n    col19: 'Column 19',\r\n    col20: 'Column 20',\r\n  },\r\n  {\r\n    id: 'row4',\r\n    col1: 'Column 1',\r\n    col2: 'Column 2',\r\n    col3: 'Column 3',\r\n    col4: 'Column 4',\r\n    col5: 'Column 5',\r\n    col6: 'Column 6',\r\n    col7: 'Column 7',\r\n    col8: 'Column 8',\r\n    col9: 'Column 9',\r\n    col10: 'Column 10',\r\n    col11: 'Column 11',\r\n    col12: 'Column 12',\r\n    col13: 'Column 13',\r\n    col14: 'Column 14',\r\n    col15: 'Column 15',\r\n    col16: 'Column 16',\r\n    col17: 'Column 17',\r\n    col18: 'Column 18',\r\n    col19: 'Column 19',\r\n    col20: 'Column 20',\r\n  },\r\n  {\r\n    id: 'row5',\r\n    col1: 'Column 1',\r\n    col2: 'Column 2',\r\n    col3: 'Column 3',\r\n    col4: 'Column 4',\r\n    col5: 'Column 5',\r\n    col6: 'Column 6',\r\n    col7: 'Column 7',\r\n    col8: 'Column 8',\r\n    col9: 'Column 9',\r\n    col10: 'Column 10',\r\n    col11: 'Column 11',\r\n    col12: 'Column 12',\r\n    col13: 'Column 13',\r\n    col14: 'Column 14',\r\n    col15: 'Column 15',\r\n    col16: 'Column 16',\r\n    col17: 'Column 17',\r\n    col18: 'Column 18',\r\n    col19: 'Column 19',\r\n    col20: 'Column 20',\r\n  },\r\n]"
+          "default": "[\n  {\n    id: 'row1',\n    col1: 'Column 1',\n    col2: 'Column 2',\n    col3: 'Column 3',\n    col4: 'Column 4',\n    col5: 'Column 5',\n    col6: 'Column 6',\n    col7: 'Column 7',\n    col8: 'Column 8',\n    col9: 'Column 9',\n    col10: 'Column 10',\n    col11: 'Column 11',\n    col12: 'Column 12',\n    col13: 'Column 13',\n    col14: 'Column 14',\n    col15: 'Column 15',\n    col16: 'Column 16',\n    col17: 'Column 17',\n    col18: 'Column 18',\n    col19: 'Column 19',\n    col20: 'Column 20',\n  },\n  {\n    id: 'row2',\n    col1: 'Column 1',\n    col2: 'Column 2',\n    col3: 'Column 3',\n    col4: 'Column 4',\n    col5: 'Column 5',\n    col6: 'Column 6',\n    col7: 'Column 7',\n    col8: 'Column 8',\n    col9: 'Column 9',\n    col10: 'Column 10',\n    col11: 'Column 11',\n    col12: 'Column 12',\n    col13: 'Column 13',\n    col14: 'Column 14',\n    col15: 'Column 15',\n    col16: 'Column 16',\n    col17: 'Column 17',\n    col18: 'Column 18',\n    col19: 'Column 19',\n    col20: 'Column 20',\n  },\n  {\n    id: 'row3',\n    col1: 'Column 1',\n    col2: 'Column 2',\n    col3: 'Column 3',\n    col4: 'Column 4',\n    col5: 'Column 5',\n    col6: 'Column 6',\n    col7: 'Column 7',\n    col8: 'Column 8',\n    col9: 'Column 9',\n    col10: 'Column 10',\n    col11: 'Column 11',\n    col12: 'Column 12',\n    col13: 'Column 13',\n    col14: 'Column 14',\n    col15: 'Column 15',\n    col16: 'Column 16',\n    col17: 'Column 17',\n    col18: 'Column 18',\n    col19: 'Column 19',\n    col20: 'Column 20',\n  },\n  {\n    id: 'row4',\n    col1: 'Column 1',\n    col2: 'Column 2',\n    col3: 'Column 3',\n    col4: 'Column 4',\n    col5: 'Column 5',\n    col6: 'Column 6',\n    col7: 'Column 7',\n    col8: 'Column 8',\n    col9: 'Column 9',\n    col10: 'Column 10',\n    col11: 'Column 11',\n    col12: 'Column 12',\n    col13: 'Column 13',\n    col14: 'Column 14',\n    col15: 'Column 15',\n    col16: 'Column 16',\n    col17: 'Column 17',\n    col18: 'Column 18',\n    col19: 'Column 19',\n    col20: 'Column 20',\n  },\n  {\n    id: 'row5',\n    col1: 'Column 1',\n    col2: 'Column 2',\n    col3: 'Column 3',\n    col4: 'Column 4',\n    col5: 'Column 5',\n    col6: 'Column 6',\n    col7: 'Column 7',\n    col8: 'Column 8',\n    col9: 'Column 9',\n    col10: 'Column 10',\n    col11: 'Column 11',\n    col12: 'Column 12',\n    col13: 'Column 13',\n    col14: 'Column 14',\n    col15: 'Column 15',\n    col16: 'Column 16',\n    col17: 'Column 17',\n    col18: 'Column 18',\n    col19: 'Column 19',\n    col20: 'Column 20',\n  },\n]"
         }
       ],
       "exports": [

--- a/src/components/reusable/modal/modal.stories.js
+++ b/src/components/reusable/modal/modal.stories.js
@@ -30,6 +30,7 @@ const args = {
   labelText: '',
   okText: 'OK',
   cancelText: 'Cancel',
+  closeText: 'Close',
   destructive: false,
   okDisabled: false,
   hideFooter: false,
@@ -50,6 +51,7 @@ export const Modal = {
         labelText=${args.labelText}
         okText=${args.okText}
         cancelText=${args.cancelText}
+        closeText=${args.closeText}
         ?destructive=${args.destructive}
         ?okDisabled=${args.okDisabled}
         ?hideFooter=${args.hideFooter}
@@ -74,6 +76,7 @@ export const ActionButtons = {
         labelText=${args.labelText}
         okText=${args.okText}
         cancelText=${args.cancelText}
+        closeText=${args.closeText}
         ?destructive=${args.destructive}
         ?okDisabled=${args.okDisabled}
         ?hideFooter=${args.hideFooter}
@@ -140,6 +143,7 @@ export const BeforeClose = {
         titleText=${args.titleText}
         labelText=${args.labelText}
         okText=${args.okText}
+        closeText=${args.closeText}
         cancelText=${args.cancelText}
         ?destructive=${args.destructive}
         ?okDisabled=${args.okDisabled}
@@ -173,6 +177,7 @@ export const WithForm = {
         labelText=${args.labelText}
         okText=${args.okText}
         cancelText=${args.cancelText}
+        closeText=${args.closeText}
         ?destructive=${args.destructive}
         ?okDisabled=${args.okDisabled}
         ?hideFooter=${args.hideFooter}

--- a/src/components/reusable/modal/modal.ts
+++ b/src/components/reusable/modal/modal.ts
@@ -92,6 +92,10 @@ export class Modal extends LitElement {
   @property({ attribute: false })
   beforeClose!: Function;
 
+  /** Close button text. */
+  @property({ type: String })
+  closeText = 'Close';
+
   /** The dialog element
    * @internal
    */
@@ -119,7 +123,8 @@ export class Modal extends LitElement {
         <form method="dialog">
           <button
             class="close"
-            aria-label="close"
+            title=${this.closeText}
+            aria-label=${this.closeText}
             @click=${(e: Event) => this._closeModal(e, 'cancel')}
           >
             <kd-icon .icon=${closeIcon}></kd-icon>

--- a/src/components/reusable/modal/modal.ts
+++ b/src/components/reusable/modal/modal.ts
@@ -119,6 +119,7 @@ export class Modal extends LitElement {
         <form method="dialog">
           <button
             class="close"
+            aria-label="close"
             @click=${(e: Event) => this._closeModal(e, 'cancel')}
           >
             <kd-icon .icon=${closeIcon}></kd-icon>


### PR DESCRIPTION
## Summary

**RCA:** 
Using VoiceOver Modal - Close button is not read as Close Button, it just reads as Button

**Solution :** 
Added "aria-lable" to the  close button icon to get identified by the voice over .

## ADO Story or GitHub Issue Link

https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/1904497


## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [x] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [x] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Testing Instructions

Use system Voiceover to test this fix

## Screenshots


https://github.com/user-attachments/assets/ec280463-fda6-4186-81e4-5d451a095d58


<img width="1126" alt="image" src="https://github.com/user-attachments/assets/5c8ea797-a09d-4c9c-8383-b6a043bb648c">



