### PR TITLE
fix: remove unnecessary bounding contexts created by transforms

### DIFF
--- a/src/components/global/header/headerFlyout.scss
+++ b/src/components/global/header/headerFlyout.scss
@@ -104,7 +104,7 @@
 
     &.open {
       .menu__content {
-        transform: translateX(0);
+        transform: none;
         z-index: 2;
       }
     }

--- a/src/components/global/header/headerLink.scss
+++ b/src/components/global/header/headerLink.scss
@@ -147,7 +147,7 @@ kyn-text-input {
 
     &.open {
       .menu__content {
-        transform: scaleX(1);
+        transform: none;
         z-index: 2;
       }
     }

--- a/src/components/global/localNav/localNavLink.scss
+++ b/src/components/global/localNav/localNavLink.scss
@@ -125,7 +125,7 @@ a {
   .link-expanded.nav-expanded & {
     visibility: visible;
     opacity: 1;
-    transform: scaleX(1);
+    transform: none;
 
     @media (min-width: 42rem) {
       transform: none;

--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -121,7 +121,7 @@
 
   &.open {
     visibility: visible;
-    transform: scaleY(1);
+    transform: none;
     opacity: 1;
     z-index: 11;
   }

--- a/src/components/reusable/modal/modal.scss
+++ b/src/components/reusable/modal/modal.scss
@@ -59,7 +59,7 @@ form {
     &[open] {
       animation: none;
       opacity: 1;
-      transform: scale(1);
+      transform: none;
 
       &::backdrop {
         background-color: rgba(0, 0, 0, 0.4);
@@ -76,7 +76,7 @@ form {
 
   100% {
     opacity: 1;
-    transform: scale(1);
+    transform: none;
   }
 }
 

--- a/src/components/reusable/notification/notification.scss
+++ b/src/components/reusable/notification/notification.scss
@@ -143,6 +143,6 @@ kd-card.notification-mark-read::part(card-wrapper) {
     transform: translateX(100%);
   }
   to {
-    transform: translateX(0);
+    transform: none;
   }
 }

--- a/src/components/reusable/overflowMenu/overflowMenu.scss
+++ b/src/components/reusable/overflowMenu/overflowMenu.scss
@@ -54,7 +54,7 @@ button {
   &.open {
     opacity: 1;
     visibility: visible;
-    transform: scale(1);
+    transform: none;
   }
 
   &.upwards {

--- a/src/components/reusable/search/search.scss
+++ b/src/components/reusable/search/search.scss
@@ -49,7 +49,7 @@ kyn-text-input {
   .focused.has-value &,
   &:focus {
     visibility: visible;
-    transform: scaleY(1);
+    transform: none;
     opacity: 1;
     z-index: 1;
   }

--- a/src/components/reusable/sideDrawer/sideDrawer.scss
+++ b/src/components/reusable/sideDrawer/sideDrawer.scss
@@ -171,7 +171,7 @@ h1 {
 
     &[open] {
       animation: none;
-      transform: translateX(0);
+      transform: none;
 
       &::backdrop {
         background-color: rgba(0, 0, 0, 0.4);
@@ -184,6 +184,6 @@ h1 {
     transform: translateX(100%);
   }
   100% {
-    transform: translateX(0);
+    transform: none;
   }
 }

--- a/src/components/reusable/stepper/stepperItem.scss
+++ b/src/components/reusable/stepper/stepperItem.scss
@@ -281,13 +281,9 @@ p {
 }
 
 .children {
-  opacity: 0;
-  transform: scaleY(0);
   display: none;
-  transition: all 200ms ease-out;
+
   &.open {
-    opacity: 1;
     display: block;
-    transform: scaleY(1);
   }
 }


### PR DESCRIPTION
## Summary

`transfrom`s create a bounding context which throws off the placement of absolute and fixed position elements. Example: using a Tooltip inside of a Modal. Switching the open states to `transform: none` maintains the transitions/animations while also removing that bounding context.
