### PR TITLE
feat: counter for textArea and textInput

### DIFF
--- a/src/components/reusable/textArea/textArea.scss
+++ b/src/components/reusable/textArea/textArea.scss
@@ -24,11 +24,14 @@ textarea {
   right: 16px;
 }
 
-.count {
-  @include typography.type-ui-03;
-  position: absolute;
-  right: 22px;
-  bottom: 6px;
-  padding: 2px;
-  background: var(--kd-color-background-inverse);
+.caption-error-count {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  .count {
+    @include typography.type-ui-03;
+    margin-top: 13px;
+    margin-left: auto;
+    background: var(--kd-color-background-inverse);
+  }
 }

--- a/src/components/reusable/textArea/textArea.scss
+++ b/src/components/reusable/textArea/textArea.scss
@@ -28,10 +28,9 @@ textarea {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+  gap: 1rem;
   .count {
     @include typography.type-ui-03;
     margin-top: 13px;
-    margin-left: auto;
-    background: var(--kd-color-background-inverse);
   }
 }

--- a/src/components/reusable/textArea/textArea.scss
+++ b/src/components/reusable/textArea/textArea.scss
@@ -30,7 +30,8 @@ textarea {
   justify-content: space-between;
   gap: 1rem;
   .count {
-    @include typography.type-ui-03;
+    @include typography.type-ui-02;
+    color: var(--kd-color-text-secondary);
     margin-top: 13px;
   }
 }

--- a/src/components/reusable/textArea/textArea.ts
+++ b/src/components/reusable/textArea/textArea.ts
@@ -111,23 +111,27 @@ ${this.value}</textarea
                 ></kd-icon>
               `
             : null}
+        </div>
+
+        <div class="caption-error-count">
+          <div>
+            ${this.caption !== ''
+              ? html` <div class="caption">${this.caption}</div> `
+              : null}
+            ${this._isInvalid
+              ? html`
+                  <div id="error" class="error">
+                    ${this.invalidText || this._internalValidationMsg}
+                  </div>
+                `
+              : null}
+          </div>
           ${this.maxLength
             ? html`
                 <div class="count">${this.value.length}/${this.maxLength}</div>
               `
             : null}
         </div>
-
-        ${this.caption !== ''
-          ? html` <div class="caption">${this.caption}</div> `
-          : null}
-        ${this._isInvalid
-          ? html`
-              <div id="error" class="error">
-                ${this.invalidText || this._internalValidationMsg}
-              </div>
-            `
-          : null}
       </div>
     `;
   }

--- a/src/components/reusable/textInput/textInput.scss
+++ b/src/components/reusable/textInput/textInput.scss
@@ -95,10 +95,9 @@ input[type='search']::-webkit-search-results-decoration {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+  gap: 1rem;
   .count {
     @include typography.type-ui-03;
     margin-top: 13px;
-    margin-left: auto;
-    background: var(--kd-color-background-inverse);
   }
 }

--- a/src/components/reusable/textInput/textInput.scss
+++ b/src/components/reusable/textInput/textInput.scss
@@ -97,7 +97,8 @@ input[type='search']::-webkit-search-results-decoration {
   justify-content: space-between;
   gap: 1rem;
   .count {
-    @include typography.type-ui-03;
+    @include typography.type-ui-02;
+    color: var(--kd-color-text-secondary);
     margin-top: 13px;
   }
 }

--- a/src/components/reusable/textInput/textInput.scss
+++ b/src/components/reusable/textInput/textInput.scss
@@ -1,5 +1,6 @@
 @use '../../../common/scss/global.scss';
 @use '../../../common/scss/form-input.scss';
+@use '~@kyndryl-design-system/shidoka-foundation/scss/mixins/typography.scss';
 
 :host {
   display: inline-block;
@@ -87,5 +88,17 @@ input[type='search']::-webkit-search-results-decoration {
 
   kd-icon {
     display: block;
+  }
+}
+
+.caption-error-count {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  .count {
+    @include typography.type-ui-03;
+    margin-top: 13px;
+    margin-left: auto;
+    background: var(--kd-color-background-inverse);
   }
 }

--- a/src/components/reusable/textInput/textInput.ts
+++ b/src/components/reusable/textInput/textInput.ts
@@ -160,16 +160,25 @@ export class TextInput extends FormMixin(LitElement) {
             : null}
         </div>
 
-        ${this.caption !== ''
-          ? html` <div class="caption">${this.caption}</div> `
-          : null}
-        ${this._isInvalid
-          ? html`
-              <div id="error" class="error">
-                ${this.invalidText || this._internalValidationMsg}
-              </div>
-            `
-          : null}
+        <div class="caption-error-count">
+          <div>
+            ${this.caption !== ''
+              ? html` <div class="caption">${this.caption}</div> `
+              : null}
+            ${this._isInvalid
+              ? html`
+                  <div id="error" class="error">
+                    ${this.invalidText || this._internalValidationMsg}
+                  </div>
+                `
+              : null}
+          </div>
+          ${this.maxLength
+            ? html`
+                <div class="count">${this.value.length}/${this.maxLength}</div>
+              `
+            : null}
+        </div>
       </div>
     `;
   }


### PR DESCRIPTION
## Summary

Moved char counter below the Text Area.
Add char counter below the Text Input and only show counter when maxLength is provided.

## ADO Story or GitHub Issue Link

https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/1918161

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots

![image](https://github.com/user-attachments/assets/b75124d3-2a88-4157-83ef-5fe2ce359066)

