### PR TITLE
feat(carousel): add shidoka swiper config, styles, examples

### DIFF
--- a/.storybook/global.scss
+++ b/.storybook/global.scss
@@ -1,3 +1,4 @@
 @use '~@kyndryl-design-system/shidoka-foundation/scss/root.scss';
 @use '~@kyndryl-design-system/shidoka-foundation/scss/utility/index.scss';
 @use '../src/common/scss/utility/gridstack-shidoka.scss';
+@use '../src/common/scss/utility/swiper-shidoka.scss';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@carbon/icon-helpers": "^10.37.0",
         "@carbon/icons": "^11.43.0",
+        "@kyndryl-design-system/shidoka-icons": "^1.1.0",
         "@lit/context": "^1.1.0",
         "deepmerge-ts": "^7.1.0",
         "gridstack": "^10.1.2",
@@ -30,7 +31,7 @@
         "@commitlint/config-conventional": "^17.4.4",
         "@custom-elements-manifest/analyzer": "^0.9.4",
         "@kyndryl-design-system/shidoka-charts": "^1.6.5",
-        "@kyndryl-design-system/shidoka-foundation": "^1.8.1",
+        "@kyndryl-design-system/shidoka-foundation": "^1.8.2",
         "@open-wc/testing": "^3.1.7",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-json": "^6.1.0",
@@ -98,7 +99,7 @@
         "typescript": "^4.9.4"
       },
       "peerDependencies": {
-        "@kyndryl-design-system/shidoka-foundation": "^1.8.1"
+        "@kyndryl-design-system/shidoka-foundation": "^1.8.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4223,16 +4224,22 @@
       }
     },
     "node_modules/@kyndryl-design-system/shidoka-foundation": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-1.8.1.tgz",
-      "integrity": "sha512-cEW6VrZzujJReE577mam30xgFcSHvJeOdH2tcv7BkoWAOkAVkd7HKQerSIdvJqXGA4Q1Pf6SHW+c+ZiqvPeYYg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-1.8.2.tgz",
+      "integrity": "sha512-uFqwsdBomxBEjM542qNth1P8B2vkHmU8JykcA3NCnQ614yqPxfI02OnqPGqPaJ9hc485iE+42olpQ0qYaeDi4g==",
       "dev": true,
       "dependencies": {
         "@carbon/icon-helpers": "^10.37.0",
         "@carbon/icons": "^11.14.0",
+        "@kyndryl-design-system/shidoka-icons": "^1.1.0",
         "lit": "^2.5.0",
         "query-selector-shadow-dom": "^1.0.1"
       }
+    },
+    "node_modules/@kyndryl-design-system/shidoka-icons": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-icons/-/shidoka-icons-1.1.0.tgz",
+      "integrity": "sha512-Hiw1iGrAK5VDdGgD4cvL0m9NVgE5tjZ8JrunftC6YqVaqLGZtvaf8CDA9KtRFFuiHJRKng4NlkjJHN1kpDOn/A=="
     },
     "node_modules/@lit-labs/react": {
       "version": "1.2.1",
@@ -35620,16 +35627,22 @@
       }
     },
     "@kyndryl-design-system/shidoka-foundation": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-1.8.1.tgz",
-      "integrity": "sha512-cEW6VrZzujJReE577mam30xgFcSHvJeOdH2tcv7BkoWAOkAVkd7HKQerSIdvJqXGA4Q1Pf6SHW+c+ZiqvPeYYg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-1.8.2.tgz",
+      "integrity": "sha512-uFqwsdBomxBEjM542qNth1P8B2vkHmU8JykcA3NCnQ614yqPxfI02OnqPGqPaJ9hc485iE+42olpQ0qYaeDi4g==",
       "dev": true,
       "requires": {
         "@carbon/icon-helpers": "^10.37.0",
         "@carbon/icons": "^11.14.0",
+        "@kyndryl-design-system/shidoka-icons": "^1.1.0",
         "lit": "^2.5.0",
         "query-selector-shadow-dom": "^1.0.1"
       }
+    },
+    "@kyndryl-design-system/shidoka-icons": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-icons/-/shidoka-icons-1.1.0.tgz",
+      "integrity": "sha512-Hiw1iGrAK5VDdGgD4cvL0m9NVgE5tjZ8JrunftC6YqVaqLGZtvaf8CDA9KtRFFuiHJRKng4NlkjJHN1kpDOn/A=="
     },
     "@lit-labs/react": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "gridstack": "^10.1.2",
         "lit": "^2.7.6",
         "lottie-web": "^5.12.2",
-        "query-selector-shadow-dom": "^1.0.1"
+        "query-selector-shadow-dom": "^1.0.1",
+        "swiper": "^11.1.12"
       },
       "devDependencies": {
         "@babel/core": "^7.20.12",
@@ -34875,6 +34876,24 @@
         "node": ">= 10"
       }
     },
+    "node_modules/swiper": {
+      "version": "11.1.12",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.12.tgz",
+      "integrity": "sha512-PUkCToYAZMB4kP7z+YfPnkMHOMwMO71g8vUhz2o5INGIgIMb6Sb0XiP6cEJFsiFTd7FRDn5XCbg+KVKPDZqXLw==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "engines": {
+        "node": ">= 4.7.0"
+      }
+    },
     "node_modules/synchronous-promise": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
@@ -61028,6 +61047,11 @@
           "dev": true
         }
       }
+    },
+    "swiper": {
+      "version": "11.1.12",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.12.tgz",
+      "integrity": "sha512-PUkCToYAZMB4kP7z+YfPnkMHOMwMO71g8vUhz2o5INGIgIMb6Sb0XiP6cEJFsiFTd7FRDn5XCbg+KVKPDZqXLw=="
     },
     "synchronous-promise": {
       "version": "2.0.17",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@carbon/icon-helpers": "^10.37.0",
     "@carbon/icons": "^11.43.0",
+    "@kyndryl-design-system/shidoka-icons": "^1.1.0",
     "@lit/context": "^1.1.0",
     "deepmerge-ts": "^7.1.0",
     "gridstack": "^10.1.2",
@@ -40,7 +41,7 @@
     "swiper": "^11.1.12"
   },
   "peerDependencies": {
-    "@kyndryl-design-system/shidoka-foundation": "^1.8.1"
+    "@kyndryl-design-system/shidoka-foundation": "^1.8.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",
@@ -53,7 +54,7 @@
     "@commitlint/config-conventional": "^17.4.4",
     "@custom-elements-manifest/analyzer": "^0.9.4",
     "@kyndryl-design-system/shidoka-charts": "^1.6.5",
-    "@kyndryl-design-system/shidoka-foundation": "^1.8.1",
+    "@kyndryl-design-system/shidoka-foundation": "^1.8.2",
     "@open-wc/testing": "^3.1.7",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-json": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "gridstack": "^10.1.2",
     "lit": "^2.7.6",
     "lottie-web": "^5.12.2",
-    "query-selector-shadow-dom": "^1.0.1"
+    "query-selector-shadow-dom": "^1.0.1",
+    "swiper": "^11.1.12"
   },
   "peerDependencies": {
     "@kyndryl-design-system/shidoka-foundation": "^1.7.5"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,7 @@ export default {
       targets: [
         { src: 'package.json', dest: 'dist' },
         { src: 'README.md', dest: 'dist' },
-        { src: 'src/common/scss', dest: 'dist/common/scss' },
+        { src: 'src/common/scss', dest: 'dist/common' },
       ],
     }),
     InlineSvg(),

--- a/src/common/helpers/swiper.ts
+++ b/src/common/helpers/swiper.ts
@@ -11,6 +11,10 @@ export const SwiperConfig = {
   keyboard: {
     enabled: true,
   },
+  mousewheel: {
+    enabled: true,
+    forceToAxis: true,
+  },
   navigation: {
     nextEl: '.swiper-button-next',
     prevEl: '.swiper-button-prev',

--- a/src/common/helpers/swiper.ts
+++ b/src/common/helpers/swiper.ts
@@ -41,8 +41,10 @@ const DetectOffScreen = (swiper: any) => {
 
     if (SlideBounds.left < 0 || SlideBounds.right > SwiperWidth) {
       slide.classList.add('off-screen');
+      slide.setAttribute('aria-disabled', 'true');
     } else {
       slide.classList.remove('off-screen');
+      slide.setAttribute('aria-disabled', 'false');
     }
   });
 };

--- a/src/common/helpers/swiper.ts
+++ b/src/common/helpers/swiper.ts
@@ -38,7 +38,7 @@ const DetectOffScreen = (swiper: any) => {
     const SlideBounds = slide.getBoundingClientRect();
 
     if (
-      SlideBounds.left < 0 ||
+      SlideBounds.left < SwiperBounds.left ||
       SlideBounds.right > SwiperBounds.width + SwiperBounds.left
     ) {
       slide.classList.add('off-screen');

--- a/src/common/helpers/swiper.ts
+++ b/src/common/helpers/swiper.ts
@@ -1,0 +1,48 @@
+export const SwiperConfig = {
+  slidesPerView: 1.25,
+  centeredSlides: true,
+  // slidesPerGroupSkip: 1,
+  // slidesPerGroup: 2,
+  spaceBetween: 16,
+  breakpoints: {
+    672: {
+      slidesPerView: 'auto',
+      spaceBetween: 24,
+    },
+  },
+  navigation: {
+    nextEl: '.swiper-button-next',
+    prevEl: '.swiper-button-prev',
+  },
+  scrollbar: {
+    el: '.swiper-scrollbar',
+    draggable: true,
+  },
+  pagination: {
+    el: '.swiper-pagination',
+    clickable: true,
+    type: 'fraction',
+  },
+  on: {
+    init: function (swiper: any) {
+      DetectOffScreen(swiper);
+    },
+    slideChangeTransitionEnd: function (swiper: any) {
+      DetectOffScreen(swiper);
+    },
+  },
+};
+
+const DetectOffScreen = (swiper: any) => {
+  const SwiperWidth = swiper.el.getBoundingClientRect().width;
+
+  swiper.slides.forEach((slide: any) => {
+    const SlideBounds = slide.getBoundingClientRect();
+
+    if (SlideBounds.left < 0 || SlideBounds.right > SwiperWidth) {
+      slide.classList.add('off-screen');
+    } else {
+      slide.classList.remove('off-screen');
+    }
+  });
+};

--- a/src/common/helpers/swiper.ts
+++ b/src/common/helpers/swiper.ts
@@ -1,8 +1,6 @@
 export const SwiperConfig = {
   slidesPerView: 1.25,
   centeredSlides: true,
-  // slidesPerGroupSkip: 1,
-  // slidesPerGroup: 2,
   spaceBetween: 16,
   breakpoints: {
     672: {
@@ -34,12 +32,15 @@ export const SwiperConfig = {
 };
 
 const DetectOffScreen = (swiper: any) => {
-  const SwiperWidth = swiper.el.getBoundingClientRect().width;
+  const SwiperBounds = swiper.el.getBoundingClientRect();
 
   swiper.slides.forEach((slide: any) => {
     const SlideBounds = slide.getBoundingClientRect();
 
-    if (SlideBounds.left < 0 || SlideBounds.right > SwiperWidth) {
+    if (
+      SlideBounds.left < 0 ||
+      SlideBounds.right > SwiperBounds.width + SwiperBounds.left
+    ) {
       slide.classList.add('off-screen');
       slide.setAttribute('aria-disabled', 'true');
     } else {

--- a/src/common/helpers/swiper.ts
+++ b/src/common/helpers/swiper.ts
@@ -8,6 +8,9 @@ export const SwiperConfig = {
       spaceBetween: 24,
     },
   },
+  keyboard: {
+    enabled: true,
+  },
   navigation: {
     nextEl: '.swiper-button-next',
     prevEl: '.swiper-button-prev',

--- a/src/common/scss/utility/gridstack-shidoka.scss
+++ b/src/common/scss/utility/gridstack-shidoka.scss
@@ -1,5 +1,5 @@
-@use '../../../../node_modules/gridstack/dist/src/gridstack.scss';
-@use '../../../../node_modules/gridstack/dist/src/gridstack-extra.scss';
+@import '../../../../node_modules/gridstack/dist/src/gridstack.scss';
+@import '../../../../node_modules/gridstack/dist/src/gridstack-extra.scss';
 
 /* set a max width on the grid */
 .grid-stack {

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -46,7 +46,7 @@
   &.tabs {
     @media (min-width: 42rem) {
       order: -1;
-      gap: 2px;
+      gap: 24px;
       overflow-x: auto;
     }
   }

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -139,6 +139,14 @@
   }
 }
 
+.pagination-with-link {
+  @include typography.type-ui-02;
+  display: flex;
+  align-items: baseline;
+  gap: 40px;
+  padding-right: 4px;
+}
+
 .swiper-button-prev,
 .swiper-button-next {
   @include elevation.shadow(2);

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -17,8 +17,15 @@
 }
 
 .swiper-slide {
+  transition: opacity 250ms ease-in-out;
+
   @media (min-width: 42rem) {
     max-width: calc(100% - var(--swiper-navigation-size) * 2 - 42px * 2);
+  }
+
+  &.off-screen {
+    opacity: 0.5;
+    pointer-events: none;
   }
 }
 
@@ -29,8 +36,10 @@
   gap: 16px;
 
   &.tabs {
-    order: -1;
-    display: block;
+    @media (min-width: 42rem) {
+      order: -1;
+      display: block;
+    }
   }
 }
 
@@ -46,17 +55,27 @@
   }
 
   .tabs & {
-    width: auto;
-    height: auto;
-    border-radius: initial;
-    border: none;
-    background: none;
-    padding: 12px 14px;
-    white-space: nowrap;
+    @media (min-width: 42rem) {
+      width: auto;
+      height: auto;
+      border-radius: initial;
+      border: none;
+      background: none;
+      padding: 12px 14px;
+      white-space: nowrap;
 
-    &-active {
-      color: var(--kd-color-text-link);
-      border-bottom: 2px solid var(--kd-color-border-tertiary);
+      &-active {
+        color: var(--kd-color-text-link);
+        border-bottom: 2px solid var(--kd-color-border-tertiary);
+      }
+    }
+
+    .tab-text {
+      display: none;
+
+      @media (min-width: 42rem) {
+        display: inline;
+      }
     }
   }
 }

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -3,10 +3,14 @@
 @use '../../../../node_modules/@kyndryl-design-system/shidoka-foundation/scss/mixins/elevation.scss';
 
 :root {
-  --swiper-navigation-size: 72px;
+  --swiper-navigation-size: 56px;
   --swiper-fractional-height: 54px;
   --swiper-bullets-height: 32px;
   --swiper-tabs-height: 64px;
+
+  @media (min-width: 82rem) {
+    --swiper-navigation-size: 64px;
+  }
 }
 
 .swiper {
@@ -44,6 +48,12 @@
       order: -1;
       display: block;
     }
+  }
+
+  kd-link,
+  a {
+    margin-left: 40px;
+    margin-right: 4px;
   }
 }
 
@@ -106,8 +116,8 @@
   @include elevation.shadow(2);
   display: none;
   border-radius: 50%;
-  width: 72px;
-  height: 72px;
+  width: var(--swiper-navigation-size);
+  height: var(--swiper-navigation-size);
   margin-top: calc(
     0px - var(--swiper-navigation-size) / 2 - var(--swiper-fractional-height) /
       2

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -4,6 +4,9 @@
 
 :root {
   --swiper-navigation-size: 72px;
+  --swiper-fractional-height: 54px;
+  --swiper-bullets-height: 32px;
+  --swiper-tabs-height: 64px;
 }
 
 .swiper {
@@ -17,6 +20,7 @@
 }
 
 .swiper-slide {
+  box-sizing: border-box;
   transition: opacity 250ms ease-in-out;
 
   @media (min-width: 42rem) {
@@ -61,7 +65,7 @@
       border-radius: initial;
       border: none;
       background: none;
-      padding: 12px 14px;
+      padding: 12px 14px 10px;
       white-space: nowrap;
 
       &-active {
@@ -104,9 +108,25 @@
   border-radius: 50%;
   width: 72px;
   height: 72px;
+  margin-top: calc(
+    0px - var(--swiper-navigation-size) / 2 - var(--swiper-fractional-height) /
+      2
+  );
   background: var(--kd-color-background-ui-default);
   outline: 2px solid transparent;
   transition: outline-color 150ms ease-out;
+
+  .swiper-pagination-bullets ~ & {
+    margin-top: calc(
+      0px - var(--swiper-navigation-size) / 2 - var(--swiper-bullets-height) / 2
+    );
+  }
+
+  .swiper-pagination-bullets.tabs ~ & {
+    margin-top: calc(
+      0px - var(--swiper-navigation-size) / 2 + var(--swiper-tabs-height) / 2
+    );
+  }
 
   @media (min-width: 42rem) {
     display: flex;

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -19,6 +19,11 @@
   gap: 16px;
 }
 
+.swiper-wrapper,
+.swiper-pagination {
+  padding: 1px;
+}
+
 .swiper-full-bleed {
   margin: 0 calc(var(--kd-page-gutter) * -1);
 }

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -46,7 +46,7 @@
   &.tabs {
     @media (min-width: 42rem) {
       order: -1;
-      display: block;
+      gap: 2px;
     }
   }
 
@@ -74,13 +74,35 @@
       height: auto;
       border-radius: initial;
       border: none;
-      background: none;
-      padding: 12px 14px 10px;
+      padding: 12px;
       white-space: nowrap;
+      outline-offset: -2px;
+      transition: border-color 150ms ease-out, background-color 150ms ease-out,
+        color 150ms ease-out, outline-color 150ms ease-out;
+      outline: 2px solid transparent;
+      border-bottom: 2px solid var(--kd-color-border-default);
+      background: none;
+
+      &:hover {
+        color: var(--kd-color-text-link-hover);
+        border-color: var(--kd-color-border-ui-hover);
+        background-color: var(--kd-color-background-inverse-hover);
+      }
+
+      &:active {
+        color: var(--kd-color-text-pressed);
+        border-color: var(--kd-color-border-ui-hover);
+        background-color: var(--kd-color-background-inverse-hover);
+      }
+
+      &:focus {
+        outline-color: var(--kd-color-border-focus);
+      }
 
       &-active {
         color: var(--kd-color-text-link);
         border-bottom: 2px solid var(--kd-color-border-tertiary);
+        font-weight: 500;
       }
     }
 

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -1,6 +1,6 @@
 @use '../../../../node_modules/swiper/swiper-bundle.min.css';
-@use '~@kyndryl-design-system/shidoka-foundation/scss/mixins/typography.scss';
-@use '~@kyndryl-design-system/shidoka-foundation/scss/mixins/elevation.scss';
+@use '../../../../node_modules/@kyndryl-design-system/shidoka-foundation/scss/mixins/typography.scss';
+@use '../../../../node_modules/@kyndryl-design-system/shidoka-foundation/scss/mixins/elevation.scss';
 
 :root {
   --swiper-navigation-size: 72px;

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -40,13 +40,13 @@
 .swiper-pagination {
   position: static;
   display: flex;
-  justify-content: center;
   gap: 16px;
 
   &.tabs {
     @media (min-width: 42rem) {
       order: -1;
       gap: 2px;
+      overflow-x: auto;
     }
   }
 
@@ -120,6 +120,14 @@
 .swiper-pagination-horizontal.swiper-pagination-bullets
   .swiper-pagination-bullet {
   margin: 0;
+
+  &:first-child {
+    margin-left: auto;
+  }
+
+  &:last-child {
+    margin-right: auto;
+  }
 }
 
 .swiper-pagination-fraction {

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -40,6 +40,7 @@
 .swiper-pagination {
   position: static;
   display: flex;
+  justify-content: safe center;
   gap: 16px;
 
   &.tabs {
@@ -120,14 +121,6 @@
 .swiper-pagination-horizontal.swiper-pagination-bullets
   .swiper-pagination-bullet {
   margin: 0;
-
-  &:first-child {
-    margin-left: auto;
-  }
-
-  &:last-child {
-    margin-right: auto;
-  }
 }
 
 .swiper-pagination-fraction {

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -1,4 +1,5 @@
 @use '../../../../node_modules/swiper/swiper-bundle.min.css';
+@use '~@kyndryl-design-system/shidoka-foundation/scss/mixins/typography.scss';
 @use '~@kyndryl-design-system/shidoka-foundation/scss/mixins/elevation.scss';
 
 :root {
@@ -12,13 +13,7 @@
 }
 
 .swiper-full-bleed {
-  margin: 0 -16px;
-}
-
-@media (min-width: 42rem) {
-  .swiper-full-bleed {
-    margin: 0 -32px;
-  }
+  margin: 0 calc(var(--kd-page-gutter) * -1);
 }
 
 .swiper-slide {
@@ -70,6 +65,17 @@
 .swiper-pagination-horizontal.swiper-pagination-bullets
   .swiper-pagination-bullet {
   margin: 0;
+}
+
+.swiper-pagination-fraction {
+  @include typography.type-ui-02;
+  justify-content: end;
+  gap: 2px;
+  color: var(--kd-color-text-secondary);
+
+  .swiper-full-bleed & {
+    padding-right: var(--kd-page-gutter);
+  }
 }
 
 .swiper-button-prev,
@@ -133,12 +139,7 @@
   width: 100%;
 
   .swiper-full-bleed & {
-    width: calc(100% - 32px);
-    margin-left: 16px;
-
-    @media (min-width: 42rem) {
-      width: calc(100% - 64px);
-      margin-left: 32px;
-    }
+    width: calc(100% - var(--kd-page-gutter) * 2);
+    margin-left: var(--kd-page-gutter);
   }
 }

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -1,0 +1,144 @@
+@use '../../../../node_modules/swiper/swiper-bundle.min.css';
+@use '~@kyndryl-design-system/shidoka-foundation/scss/mixins/elevation.scss';
+
+:root {
+  --swiper-navigation-size: 72px;
+}
+
+.swiper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.swiper-full-bleed {
+  margin: 0 -16px;
+}
+
+@media (min-width: 42rem) {
+  .swiper-full-bleed {
+    margin: 0 -32px;
+  }
+}
+
+.swiper-slide {
+  @media (min-width: 42rem) {
+    max-width: calc(100% - var(--swiper-navigation-size) * 2 - 42px * 2);
+  }
+}
+
+.swiper-pagination {
+  position: static;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+
+  &.tabs {
+    order: -1;
+    display: block;
+  }
+}
+
+.swiper-pagination-bullet {
+  border: 1px solid var(--kd-color-border-light);
+  background: none;
+  opacity: initial;
+  width: 16px;
+  height: 16px;
+
+  &-active {
+    background: var(--kd-color-background-ui-subtle);
+  }
+
+  .tabs & {
+    width: auto;
+    height: auto;
+    border-radius: initial;
+    border: none;
+    background: none;
+    padding: 12px 14px;
+    white-space: nowrap;
+
+    &-active {
+      color: var(--kd-color-text-link);
+      border-bottom: 2px solid var(--kd-color-border-tertiary);
+    }
+  }
+}
+
+.swiper-horizontal > .swiper-pagination-bullets .swiper-pagination-bullet,
+.swiper-pagination-horizontal.swiper-pagination-bullets
+  .swiper-pagination-bullet {
+  margin: 0;
+}
+
+.swiper-button-prev,
+.swiper-button-next {
+  @include elevation.shadow(2);
+  display: none;
+  border-radius: 50%;
+  width: 72px;
+  height: 72px;
+  background: var(--kd-color-background-ui-default);
+  outline: 2px solid transparent;
+  transition: outline-color 150ms ease-out;
+
+  @media (min-width: 42rem) {
+    display: flex;
+  }
+
+  &:focus {
+    outline-color: var(--kd-color-border-focus);
+  }
+
+  &:before {
+    content: '';
+    width: 100%;
+    height: 100%;
+    background-repeat: no-repeat;
+    // background-size: 100% auto;
+    background-position: center;
+    transition: opacity 150ms ease-out;
+  }
+
+  &:hover:before {
+    opacity: 0.8;
+  }
+
+  &:after {
+    display: none;
+  }
+
+  &.swiper-button-disabled {
+    opacity: 1;
+
+    &:before {
+      opacity: 0.35;
+    }
+  }
+}
+
+.swiper-button-prev:before {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEzLjk5NzEgMjZMMTUuNDA3MSAyNC41OUw3LjgyNzA3IDE3SDI3Ljk5NzFWMTVINy44MjcwN0wxNS40MDcxIDcuNDFMMTMuOTk3MSA2TDMuOTk3MDcgMTZMMTMuOTk3MSAyNloiIGZpbGw9IiMzRDNDM0MiLz4KPC9zdmc+');
+}
+
+.swiper-button-next:before {
+  content: '';
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE4IDZMMTYuNTkgNy40MUwyNC4xNyAxNUw0IDE1VjE3TDI0LjE3IDE3TDE2LjU5IDI0LjU5TDE4IDI2TDI4IDE2TDE4IDZaIiBmaWxsPSIjM0QzQzNDIi8+Cjwvc3ZnPg==');
+}
+
+.swiper-horizontal > .swiper-scrollbar,
+.swiper-scrollbar.swiper-scrollbar-horizontal {
+  position: static;
+  width: 100%;
+
+  .swiper-full-bleed & {
+    width: calc(100% - 32px);
+    margin-left: 16px;
+
+    @media (min-width: 42rem) {
+      width: calc(100% - 64px);
+      margin-left: 32px;
+    }
+  }
+}

--- a/src/components/reusable/widget/Gridstack.mdx
+++ b/src/components/reusable/widget/Gridstack.mdx
@@ -22,14 +22,6 @@ import { UsageExample } from '../../../../.storybook/usageBlock.jsx';
 
 ### Styles
 
-#### SCSS
-
-```css
-@use '@kyndryl-design-system/shidoka-applications/common/scss/utility/gridstack-shidoka.scss';
-```
-
-#### CSS
-
 ```css
 @import '@kyndryl-design-system/shidoka-applications/common/css/gridstack-shidoka.css';
 ```

--- a/src/components/reusable/widget/Gridstack.mdx
+++ b/src/components/reusable/widget/Gridstack.mdx
@@ -31,7 +31,7 @@ import { UsageExample } from '../../../../.storybook/usageBlock.jsx';
 #### CSS
 
 ```css
-@use '@kyndryl-design-system/shidoka-applications/common/css/gridstack-shidoka.css';
+@import '@kyndryl-design-system/shidoka-applications/common/css/gridstack-shidoka.css';
 ```
 
 ## Widget Sizes

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ export {
   WidgetSizes,
   WidgetConstraints,
 } from './common/helpers/gridstack';
+export { SwiperConfig } from './common/helpers/swiper';
 
 export {
   Stepper,

--- a/src/stories/carousel/Docs.mdx
+++ b/src/stories/carousel/Docs.mdx
@@ -13,3 +13,75 @@ import Swiper from 'swiper/bundle';
 <Meta of={CarouselStories} name="Docs" />
 
 <Title />
+
+Shidoka uses [Swiper](https://swiperjs.com/), and provides a default configuration and stylesheet.
+
+## Usage
+
+### Import Swiper and the Shidoka config
+
+```js
+// import Swiper bundle with all modules installed
+import Swiper from 'swiper/bundle';
+
+// import Shidoka's Swiper config
+import { SwiperConfig } from '@kyndryl-design-system/shdioka-applications/common/helpers/swiper';
+```
+
+### Import the Shidoka styles for Swiper
+
+#### SCSS
+
+```css
+@use '@kyndryl-design-system/shidoka-applications/common/scss/utility/swiper-shidoka.scss';
+```
+
+#### CSS
+
+```css
+@import '@kyndryl-design-system/shidoka-applications/common/css/swiper-shidoka.css';
+```
+
+### Add Swiper HTML to your page
+
+Reference the Stories for more example HTML.
+
+```html
+<!-- Slider main container -->
+<div class="swiper">
+  <!-- Additional required wrapper -->
+  <div class="swiper-wrapper">
+    <!-- Slides -->
+    <div class="swiper-slide">Slide 1</div>
+    <div class="swiper-slide">Slide 2</div>
+    <div class="swiper-slide">Slide 3</div>
+    <div class="swiper-slide">Slide 4</div>
+    <div class="swiper-slide">Slide 5</div>
+    <div class="swiper-slide">Slide 6</div>
+  </div>
+
+  <!-- If we need scrollbar -->
+  <div class="swiper-scrollbar"></div>
+
+  <!-- If we need pagination -->
+  <div class="swiper-pagination"></div>
+
+  <!-- If we need navigation buttons -->
+  <div class="swiper-button-prev"></div>
+  <div class="swiper-button-next"></div>
+</div>
+```
+
+### Extend the Shidoka default Swiper config (if needed)
+
+We use [deepmerge-ts](https://www.npmjs.com/package/deepmerge-ts) for this in our example Stories.
+
+```js
+SwiperConfig.pagination.type = 'bullets';
+```
+
+### Initialize Swiper (after DOM ready)
+
+```js
+new Swiper('.swiper', SwiperConfig);
+```

--- a/src/stories/carousel/Docs.mdx
+++ b/src/stories/carousel/Docs.mdx
@@ -1,0 +1,15 @@
+import {
+  Meta,
+  Story,
+  Canvas,
+  Controls,
+  Stories,
+  Description,
+  Title,
+} from '@storybook/blocks';
+import * as CarouselStories from './carousel.stories.js';
+import Swiper from 'swiper/bundle';
+
+<Meta of={CarouselStories} name="Docs" />
+
+<Title />

--- a/src/stories/carousel/Docs.mdx
+++ b/src/stories/carousel/Docs.mdx
@@ -14,7 +14,10 @@ import Swiper from 'swiper/bundle';
 
 <Title />
 
-Shidoka uses [Swiper](https://swiperjs.com/), and provides a default configuration and stylesheet.
+Shidoka uses [Swiper](https://swiperjs.com/), and provides a [default configuration](https://github.com/kyndryl-design-system/shidoka-applications/tree/main/src/common/helpers/swiper.ts) and stylesheet.
+
+Please reference the [Swiper documentation](https://swiperjs.com/swiper-api) and
+[Swiper demos](https://swiperjs.com/demos) for anything beyond our example stories.
 
 ## Usage
 
@@ -28,7 +31,7 @@ import Swiper from 'swiper/bundle';
 import { SwiperConfig } from '@kyndryl-design-system/shdioka-applications/common/helpers/swiper';
 ```
 
-### Import the Shidoka styles for Swiper
+### Import the Shidoka styles for Swiper (globally)
 
 ```css
 @import '@kyndryl-design-system/shidoka-applications/common/css/swiper-shidoka.css';

--- a/src/stories/carousel/Docs.mdx
+++ b/src/stories/carousel/Docs.mdx
@@ -30,14 +30,6 @@ import { SwiperConfig } from '@kyndryl-design-system/shdioka-applications/common
 
 ### Import the Shidoka styles for Swiper
 
-#### SCSS
-
-```css
-@use '@kyndryl-design-system/shidoka-applications/common/scss/utility/swiper-shidoka.scss';
-```
-
-#### CSS
-
 ```css
 @import '@kyndryl-design-system/shidoka-applications/common/css/swiper-shidoka.css';
 ```

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -43,7 +43,7 @@ export default {
  * number of slides. The template includes the main swiper container, wrapper, slides, scrollbar,
  * pagination, and navigation buttons. Each slide is labeled with "Slide" followed by its index number.
  */
-const SwiperTemplate = (slides = 6) => {
+const SwiperTemplate = (slides = 6, noScrollbar = false) => {
   const Slides = [];
   for (let i = 0; i < slides; i++) {
     Slides.push(i);
@@ -61,7 +61,7 @@ const SwiperTemplate = (slides = 6) => {
       </div>
 
       <!-- If we need scrollbar -->
-      <div class="swiper-scrollbar"></div>
+      ${!noScrollbar ? html` <div class="swiper-scrollbar"></div> ` : null}
 
       <!-- If we need pagination -->
       <div class="swiper-pagination"></div>
@@ -136,7 +136,7 @@ export const PaginationBullets = {
       "bullets" style of pagination instead of "fractional".
       <br /><br />
 
-      ${SwiperTemplate()}
+      ${SwiperTemplate(6, true)}
     `;
   },
   play: async () => {
@@ -160,7 +160,7 @@ export const PaginationTabs = {
       should be limited to 5.
       <br /><br />
 
-      ${SwiperTemplate(5)}
+      ${SwiperTemplate(5, true)}
     `;
   },
   play: async () => {

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -14,7 +14,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: '',
+      url: 'https://www.figma.com/file/CQuDZEeLiuGiALvCWjAKlu/Applications---Component-Library?node-id=16511-29991&node-type=frame&m=dev',
     },
   },
   decorators: [

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -48,6 +48,9 @@ export const MiniCards = {
   ],
   render: (args) => {
     return html`
+      This example sets a width on each slide.
+      <br /><br />
+
       <!-- Slider main container -->
       <div class="swiper">
         <!-- Additional required wrapper -->
@@ -82,6 +85,9 @@ export const LargeCards = {
   args: {},
   render: (args) => {
     return html`
+      This example is unmodified, so each slide takes a full page.
+      <br /><br />
+
       <!-- Slider main container -->
       <div class="swiper">
         <!-- Additional required wrapper -->
@@ -116,6 +122,10 @@ export const FullBleed = {
   args: {},
   render: (args) => {
     return html`
+      This example adds the "swiper-full-bleed" class to extend beyond the page
+      gutter to the edge of the screen.
+      <br /><br />
+
       <!-- Slider main container -->
       <div class="swiper swiper-full-bleed">
         <!-- Additional required wrapper -->
@@ -150,6 +160,10 @@ export const PaginationBullets = {
   args: {},
   render: (args) => {
     return html`
+      This example extends the Shidoka default Swiper config to use the
+      "bullets" style of pagination instead of "fractional".
+      <br /><br />
+
       <!-- Slider main container -->
       <div class="swiper">
         <!-- Additional required wrapper -->
@@ -188,6 +202,11 @@ export const PaginationTabs = {
   args: {},
   render: (args) => {
     return html`
+      This example extends the Shidoka default Swiper config to modify the
+      "bullets" style of pagination to convert them to Tabs on larger screen
+      sizes. The class "tabs" is also added to the "swiper-pagination" div.
+      <br /><br />
+
       <!-- Slider main container -->
       <div class="swiper">
         <!-- Additional required wrapper -->

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -1,32 +1,11 @@
 import { html } from 'lit';
+import { deepmerge } from 'deepmerge-ts';
 
 // import Swiper bundle with all modules installed
 import Swiper from 'swiper/bundle';
 
-const SwiperConfig = {
-  slidesPerView: 1.25,
-  centeredSlides: true,
-  spaceBetween: 16,
-  breakpoints: {
-    672: {
-      slidesPerView: 'auto',
-      spaceBetween: 24,
-    },
-  },
-  navigation: {
-    nextEl: '.swiper-button-next',
-    prevEl: '.swiper-button-prev',
-  },
-  scrollbar: {
-    el: '.swiper-scrollbar',
-    draggable: true,
-  },
-  pagination: {
-    el: '.swiper-pagination',
-    clickable: true,
-    type: 'fraction',
-  },
-};
+// import Shidoka's Swiper config
+import { SwiperConfig } from '../../common/helpers/swiper';
 
 export default {
   title: 'Patterns/Carousel',
@@ -194,11 +173,14 @@ export const PaginationBullets = {
     `;
   },
   play: async () => {
-    const Config = JSON.parse(JSON.stringify(SwiperConfig));
+    const CustomConfig = {
+      pagination: {
+        type: 'bullets',
+      },
+    };
+    const FinalConfig = deepmerge(SwiperConfig, CustomConfig);
 
-    Config.pagination.type = 'bullets';
-
-    new Swiper('.swiper', Config);
+    new Swiper('.swiper', FinalConfig);
   },
 };
 
@@ -229,14 +211,23 @@ export const PaginationTabs = {
     `;
   },
   play: async () => {
-    const Config = JSON.parse(JSON.stringify(SwiperConfig));
-    const Tabs = ['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4', 'Tab 5', 'Tab 6'];
+    const TabTextArr = ['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4', 'Tab 5', 'Tab 6'];
 
-    Config.pagination.type = 'bullets';
-    Config.pagination.renderBullet = function (index, className) {
-      return '<span class="' + className + '">' + Tabs[index] + '</span>';
+    const CustomConfig = {
+      pagination: {
+        type: 'bullets',
+        renderBullet: function (index, className) {
+          return `
+            <span class="${className}">
+              <span class="tab-text">${TabTextArr[index]}</span>
+            </span>
+          `;
+        },
+      },
     };
 
-    new Swiper('.swiper', Config);
+    const FinalConfig = deepmerge(SwiperConfig, CustomConfig);
+
+    new Swiper('.swiper', FinalConfig);
   },
 };

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -1,5 +1,7 @@
 import { html } from 'lit';
 import { deepmerge } from 'deepmerge-ts';
+import '@kyndryl-design-system/shidoka-foundation/components/link';
+import arrowRightIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/arrow-right.svg';
 
 // import Swiper bundle with all modules installed
 import Swiper from 'swiper/bundle';
@@ -9,7 +11,6 @@ import { SwiperConfig } from '../../common/helpers/swiper';
 
 export default {
   title: 'Patterns/Carousel',
-  // component: 'kyn-carousel',
   parameters: {
     design: {
       type: 'figma',
@@ -24,7 +25,6 @@ export default {
             height: 200px;
             padding: 16px;
             background-color: var(--kd-color-background-ui-soft);
-            /* border: 1px solid var(--kd-color-border-light); */
             border-radius: 8px;
           }
         </style>
@@ -105,7 +105,7 @@ export const MiniCards = {
         <div class="swiper-scrollbar"></div>
 
         <!-- If we need pagination -->
-        <div class="swiper-pagination"></div>
+        <div class="swiper-pagination"><a>test</a></div>
 
         <!-- If we need navigation buttons -->
         <div class="swiper-button-prev"></div>
@@ -240,6 +240,59 @@ export const PaginationTabs = {
             <span class="${className}">
               <span class="tab-text">${TabTextArr[index]}</span>
             </span>
+          `;
+        },
+      },
+    };
+
+    const FinalConfig = deepmerge(SwiperConfig, CustomConfig);
+
+    new Swiper('.swiper', FinalConfig);
+  },
+};
+
+export const WithLink = {
+  args: {},
+  render: (args) => {
+    return html`
+      This example injects a link into the fractional pagination.
+      <br /><br />
+
+      <!-- Slider main container -->
+      <div class="swiper">
+        <!-- Additional required wrapper -->
+        <div class="swiper-wrapper">
+          <!-- Slides -->
+          <div class="swiper-slide">Slide 1</div>
+          <div class="swiper-slide">Slide 2</div>
+          <div class="swiper-slide">Slide 3</div>
+          <div class="swiper-slide">Slide 4</div>
+          <div class="swiper-slide">Slide 5</div>
+          <div class="swiper-slide">Slide 6</div>
+        </div>
+
+        <!-- If we need scrollbar -->
+        <div class="swiper-scrollbar"></div>
+
+        <!-- If we need pagination -->
+        <div class="swiper-pagination"></div>
+
+        <!-- If we need navigation buttons -->
+        <div class="swiper-button-prev"></div>
+        <div class="swiper-button-next"></div>
+      </div>
+    `;
+  },
+  play: async () => {
+    const CustomConfig = {
+      pagination: {
+        renderFraction: function (currentClass, totalClass) {
+          return `
+          <span class="${currentClass}"></span> / <span class="${totalClass}"></span>
+          <kd-link standalone href="javascript:void(0);">
+            View All
+            <span slot="icon">${arrowRightIcon}</span>
+          </kd-link>
           `;
         },
       },

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -1,5 +1,6 @@
 import { html } from 'lit';
 import { deepmerge } from 'deepmerge-ts';
+import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js';
 import '@kyndryl-design-system/shidoka-foundation/components/link';
 import arrowRightIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/arrow-right.svg';
 
@@ -190,29 +191,46 @@ export const PaginationTabs = {
 export const WithLink = {
   render: () => {
     return html`
-      This example injects a link into the fractional pagination.
+      This example places a link inline with the fractional pagination.
       <br /><br />
 
+      <!--
       ${SwiperTemplate()}
+      -->
+
+      <!-- Slider main container -->
+      <div class="swiper">
+        <!-- Additional required wrapper -->
+        <div class="swiper-wrapper">
+          <!-- Slides -->
+          <div class="swiper-slide">Slide 1</div>
+          <div class="swiper-slide">Slide 2</div>
+          <div class="swiper-slide">Slide 3</div>
+          <div class="swiper-slide">Slide 4</div>
+          <div class="swiper-slide">Slide 5</div>
+          <div class="swiper-slide">Slide 6</div>
+        </div>
+
+        <!-- If we need scrollbar -->
+        <div class="swiper-scrollbar"></div>
+
+        <!-- If we need pagination -->
+        <div class="pagination-with-link">
+          <div class="swiper-pagination"></div>
+
+          <kd-link standalone href="javascript:void(0);">
+            Link
+            <span slot="icon">${unsafeSVG(arrowRightIcon)}</span>
+          </kd-link>
+        </div>
+
+        <!-- If we need navigation buttons -->
+        <div class="swiper-button-prev"></div>
+        <div class="swiper-button-next"></div>
+      </div>
     `;
   },
   play: async () => {
-    const CustomConfig = {
-      pagination: {
-        renderFraction: function (currentClass, totalClass) {
-          return `
-          <span class="${currentClass}"></span> / <span class="${totalClass}"></span>
-          <kd-link standalone href="javascript:void(0);">
-            View All
-            <span slot="icon">${arrowRightIcon}</span>
-          </kd-link>
-          `;
-        },
-      },
-    };
-
-    const FinalConfig = deepmerge(SwiperConfig, CustomConfig);
-
-    new Swiper('.swiper', FinalConfig);
+    new Swiper('.swiper', SwiperConfig);
   },
 };

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -23,8 +23,8 @@ export default {
           .swiper-slide {
             height: 200px;
             padding: 16px;
-            background-color: var(--kd-color-background-ui-default);
-            border: 1px solid var(--kd-color-border-light);
+            background-color: var(--kd-color-background-ui-soft);
+            /* border: 1px solid var(--kd-color-border-light); */
             border-radius: 8px;
           }
         </style>
@@ -33,22 +33,11 @@ export default {
   ],
 };
 
-export const MiniCards = {
+export const LargeCards = {
   args: {},
-  decorators: [
-    (story) =>
-      html`
-        <style>
-          .swiper-slide {
-            width: 264px;
-          }
-        </style>
-        ${story()}
-      `,
-  ],
   render: (args) => {
     return html`
-      This example sets a width on each slide.
+      This example is unmodified, so each slide takes a full page.
       <br /><br />
 
       <!-- Slider main container -->
@@ -81,11 +70,22 @@ export const MiniCards = {
   },
 };
 
-export const LargeCards = {
+export const MiniCards = {
   args: {},
+  decorators: [
+    (story) =>
+      html`
+        <style>
+          .swiper-slide {
+            width: 264px;
+          }
+        </style>
+        ${story()}
+      `,
+  ],
   render: (args) => {
     return html`
-      This example is unmodified, so each slide takes a full page.
+      This example sets a fixed width on each slide.
       <br /><br />
 
       <!-- Slider main container -->

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -21,6 +21,7 @@ export default {
     (story) =>
       html`
         <style>
+          /* example styles, not to be used */
           .swiper-slide {
             height: 200px;
             padding: 16px;

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -24,10 +24,7 @@ const SwiperConfig = {
   pagination: {
     el: '.swiper-pagination',
     clickable: true,
-    // type: 'fraction',
-    renderBullet: function (index, className) {
-      return '<span class="' + className + '">Tab ' + (index + 1) + '</span>';
-    },
+    type: 'fraction',
   },
 };
 
@@ -85,12 +82,15 @@ export const MiniCards = {
           <div class="swiper-slide">Slide 6</div>
         </div>
 
+        <!-- If we need scrollbar -->
+        <div class="swiper-scrollbar"></div>
+
+        <!-- If we need pagination -->
+        <div class="swiper-pagination"></div>
+
         <!-- If we need navigation buttons -->
         <div class="swiper-button-prev"></div>
         <div class="swiper-button-next"></div>
-
-        <!-- If we need scrollbar -->
-        <div class="swiper-scrollbar"></div>
       </div>
     `;
   },
@@ -116,12 +116,15 @@ export const LargeCards = {
           <div class="swiper-slide">Slide 6</div>
         </div>
 
+        <!-- If we need scrollbar -->
+        <div class="swiper-scrollbar"></div>
+
+        <!-- If we need pagination -->
+        <div class="swiper-pagination"></div>
+
         <!-- If we need navigation buttons -->
         <div class="swiper-button-prev"></div>
         <div class="swiper-button-next"></div>
-
-        <!-- If we need scrollbar -->
-        <div class="swiper-scrollbar"></div>
       </div>
     `;
   },
@@ -147,12 +150,15 @@ export const FullBleed = {
           <div class="swiper-slide">Slide 6</div>
         </div>
 
+        <!-- If we need scrollbar -->
+        <div class="swiper-scrollbar"></div>
+
+        <!-- If we need pagination -->
+        <div class="swiper-pagination"></div>
+
         <!-- If we need navigation buttons -->
         <div class="swiper-button-prev"></div>
         <div class="swiper-button-next"></div>
-
-        <!-- If we need scrollbar -->
-        <div class="swiper-scrollbar"></div>
       </div>
     `;
   },
@@ -161,7 +167,7 @@ export const FullBleed = {
   },
 };
 
-export const PaginationDots = {
+export const PaginationBullets = {
   args: {},
   render: (args) => {
     return html`
@@ -177,6 +183,7 @@ export const PaginationDots = {
           <div class="swiper-slide">Slide 5</div>
           <div class="swiper-slide">Slide 6</div>
         </div>
+
         <!-- If we need pagination -->
         <div class="swiper-pagination"></div>
 
@@ -187,7 +194,11 @@ export const PaginationDots = {
     `;
   },
   play: async () => {
-    new Swiper('.swiper', SwiperConfig);
+    const Config = JSON.parse(JSON.stringify(SwiperConfig));
+
+    Config.pagination.type = 'bullets';
+
+    new Swiper('.swiper', Config);
   },
 };
 
@@ -207,6 +218,7 @@ export const PaginationTabs = {
           <div class="swiper-slide">Slide 5</div>
           <div class="swiper-slide">Slide 6</div>
         </div>
+
         <!-- If we need pagination -->
         <div class="swiper-pagination tabs"></div>
 
@@ -217,6 +229,14 @@ export const PaginationTabs = {
     `;
   },
   play: async () => {
-    new Swiper('.swiper', SwiperConfig);
+    const Config = JSON.parse(JSON.stringify(SwiperConfig));
+    const Tabs = ['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4', 'Tab 5', 'Tab 6'];
+
+    Config.pagination.type = 'bullets';
+    Config.pagination.renderBullet = function (index, className) {
+      return '<span class="' + className + '">' + Tabs[index] + '</span>';
+    };
+
+    new Swiper('.swiper', Config);
   },
 };

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -205,7 +205,8 @@ export const PaginationTabs = {
     return html`
       This example extends the Shidoka default Swiper config to modify the
       "bullets" style of pagination to convert them to Tabs on larger screen
-      sizes. The class "tabs" is also added to the "swiper-pagination" div.
+      sizes. The class "tabs" is also added to the "swiper-pagination" div. Tabs
+      should be limited to 5.
       <br /><br />
 
       <!-- Slider main container -->
@@ -218,7 +219,6 @@ export const PaginationTabs = {
           <div class="swiper-slide">Slide 3</div>
           <div class="swiper-slide">Slide 4</div>
           <div class="swiper-slide">Slide 5</div>
-          <div class="swiper-slide">Slide 6</div>
         </div>
 
         <!-- If we need pagination -->
@@ -231,7 +231,7 @@ export const PaginationTabs = {
     `;
   },
   play: async () => {
-    const TabTextArr = ['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4', 'Tab 5', 'Tab 6'];
+    const TabTextArr = ['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4', 'Tab 5'];
 
     const CustomConfig = {
       pagination: {

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -1,0 +1,222 @@
+import { html } from 'lit';
+
+// import Swiper bundle with all modules installed
+import Swiper from 'swiper/bundle';
+
+const SwiperConfig = {
+  slidesPerView: 1.25,
+  centeredSlides: true,
+  spaceBetween: 16,
+  breakpoints: {
+    672: {
+      slidesPerView: 'auto',
+      spaceBetween: 24,
+    },
+  },
+  navigation: {
+    nextEl: '.swiper-button-next',
+    prevEl: '.swiper-button-prev',
+  },
+  scrollbar: {
+    el: '.swiper-scrollbar',
+    draggable: true,
+  },
+  pagination: {
+    el: '.swiper-pagination',
+    clickable: true,
+    // type: 'fraction',
+    renderBullet: function (index, className) {
+      return '<span class="' + className + '">Tab ' + (index + 1) + '</span>';
+    },
+  },
+};
+
+export default {
+  title: 'Patterns/Carousel',
+  // component: 'kyn-carousel',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: '',
+    },
+  },
+  decorators: [
+    (story) =>
+      html`
+        <style>
+          .swiper-slide {
+            height: 200px;
+            padding: 16px;
+            background-color: var(--kd-color-background-ui-default);
+            border: 1px solid var(--kd-color-border-light);
+            border-radius: 8px;
+          }
+        </style>
+        ${story()}
+      `,
+  ],
+};
+
+export const MiniCards = {
+  args: {},
+  decorators: [
+    (story) =>
+      html`
+        <style>
+          .swiper-slide {
+            width: 264px;
+          }
+        </style>
+        ${story()}
+      `,
+  ],
+  render: (args) => {
+    return html`
+      <!-- Slider main container -->
+      <div class="swiper">
+        <!-- Additional required wrapper -->
+        <div class="swiper-wrapper">
+          <!-- Slides -->
+          <div class="swiper-slide">Slide 1</div>
+          <div class="swiper-slide">Slide 2</div>
+          <div class="swiper-slide">Slide 3</div>
+          <div class="swiper-slide">Slide 4</div>
+          <div class="swiper-slide">Slide 5</div>
+          <div class="swiper-slide">Slide 6</div>
+        </div>
+
+        <!-- If we need navigation buttons -->
+        <div class="swiper-button-prev"></div>
+        <div class="swiper-button-next"></div>
+
+        <!-- If we need scrollbar -->
+        <div class="swiper-scrollbar"></div>
+      </div>
+    `;
+  },
+  play: async () => {
+    new Swiper('.swiper', SwiperConfig);
+  },
+};
+
+export const LargeCards = {
+  args: {},
+  render: (args) => {
+    return html`
+      <!-- Slider main container -->
+      <div class="swiper">
+        <!-- Additional required wrapper -->
+        <div class="swiper-wrapper">
+          <!-- Slides -->
+          <div class="swiper-slide">Slide 1</div>
+          <div class="swiper-slide">Slide 2</div>
+          <div class="swiper-slide">Slide 3</div>
+          <div class="swiper-slide">Slide 4</div>
+          <div class="swiper-slide">Slide 5</div>
+          <div class="swiper-slide">Slide 6</div>
+        </div>
+
+        <!-- If we need navigation buttons -->
+        <div class="swiper-button-prev"></div>
+        <div class="swiper-button-next"></div>
+
+        <!-- If we need scrollbar -->
+        <div class="swiper-scrollbar"></div>
+      </div>
+    `;
+  },
+  play: async () => {
+    new Swiper('.swiper', SwiperConfig);
+  },
+};
+
+export const FullBleed = {
+  args: {},
+  render: (args) => {
+    return html`
+      <!-- Slider main container -->
+      <div class="swiper swiper-full-bleed">
+        <!-- Additional required wrapper -->
+        <div class="swiper-wrapper">
+          <!-- Slides -->
+          <div class="swiper-slide">Slide 1</div>
+          <div class="swiper-slide">Slide 2</div>
+          <div class="swiper-slide">Slide 3</div>
+          <div class="swiper-slide">Slide 4</div>
+          <div class="swiper-slide">Slide 5</div>
+          <div class="swiper-slide">Slide 6</div>
+        </div>
+
+        <!-- If we need navigation buttons -->
+        <div class="swiper-button-prev"></div>
+        <div class="swiper-button-next"></div>
+
+        <!-- If we need scrollbar -->
+        <div class="swiper-scrollbar"></div>
+      </div>
+    `;
+  },
+  play: async () => {
+    new Swiper('.swiper', SwiperConfig);
+  },
+};
+
+export const PaginationDots = {
+  args: {},
+  render: (args) => {
+    return html`
+      <!-- Slider main container -->
+      <div class="swiper">
+        <!-- Additional required wrapper -->
+        <div class="swiper-wrapper">
+          <!-- Slides -->
+          <div class="swiper-slide">Slide 1</div>
+          <div class="swiper-slide">Slide 2</div>
+          <div class="swiper-slide">Slide 3</div>
+          <div class="swiper-slide">Slide 4</div>
+          <div class="swiper-slide">Slide 5</div>
+          <div class="swiper-slide">Slide 6</div>
+        </div>
+        <!-- If we need pagination -->
+        <div class="swiper-pagination"></div>
+
+        <!-- If we need navigation buttons -->
+        <div class="swiper-button-prev"></div>
+        <div class="swiper-button-next"></div>
+      </div>
+    `;
+  },
+  play: async () => {
+    new Swiper('.swiper', SwiperConfig);
+  },
+};
+
+export const PaginationTabs = {
+  args: {},
+  render: (args) => {
+    return html`
+      <!-- Slider main container -->
+      <div class="swiper">
+        <!-- Additional required wrapper -->
+        <div class="swiper-wrapper">
+          <!-- Slides -->
+          <div class="swiper-slide">Slide 1</div>
+          <div class="swiper-slide">Slide 2</div>
+          <div class="swiper-slide">Slide 3</div>
+          <div class="swiper-slide">Slide 4</div>
+          <div class="swiper-slide">Slide 5</div>
+          <div class="swiper-slide">Slide 6</div>
+        </div>
+        <!-- If we need pagination -->
+        <div class="swiper-pagination tabs"></div>
+
+        <!-- If we need navigation buttons -->
+        <div class="swiper-button-prev"></div>
+        <div class="swiper-button-next"></div>
+      </div>
+    `;
+  },
+  play: async () => {
+    new Swiper('.swiper', SwiperConfig);
+  },
+};

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -34,36 +34,52 @@ export default {
   ],
 };
 
+/**
+ * The SwiperTemplate function generates HTML code for a slider with specified number of slides.
+ * @param [slides=6] - The `slides` parameter in the `SwiperTemplate` function represents the number of
+ * slides you want to generate for the swiper component. By default, it is set to 6, but you can pass a
+ * different number to customize the number of slides in the swiper component.
+ * @returns The SwiperTemplate function returns an HTML template for a swiper slider with a specified
+ * number of slides. The template includes the main swiper container, wrapper, slides, scrollbar,
+ * pagination, and navigation buttons. Each slide is labeled with "Slide" followed by its index number.
+ */
+const SwiperTemplate = (slides = 6) => {
+  const Slides = [];
+  for (let i = 0; i < slides; i++) {
+    Slides.push(i);
+  }
+
+  return html`
+    <!-- Slider main container -->
+    <div class="swiper">
+      <!-- Additional required wrapper -->
+      <div class="swiper-wrapper">
+        <!-- Slides -->
+        ${Slides.map((slide) => {
+          return html`<div class="swiper-slide">Slide ${slide + 1}</div>`;
+        })}
+      </div>
+
+      <!-- If we need scrollbar -->
+      <div class="swiper-scrollbar"></div>
+
+      <!-- If we need pagination -->
+      <div class="swiper-pagination"></div>
+
+      <!-- If we need navigation buttons -->
+      <div class="swiper-button-prev"></div>
+      <div class="swiper-button-next"></div>
+    </div>
+  `;
+};
+
 export const LargeCards = {
-  args: {},
-  render: (args) => {
+  render: () => {
     return html`
       This example is unmodified, so each slide takes a full page.
       <br /><br />
 
-      <!-- Slider main container -->
-      <div class="swiper">
-        <!-- Additional required wrapper -->
-        <div class="swiper-wrapper">
-          <!-- Slides -->
-          <div class="swiper-slide">Slide 1</div>
-          <div class="swiper-slide">Slide 2</div>
-          <div class="swiper-slide">Slide 3</div>
-          <div class="swiper-slide">Slide 4</div>
-          <div class="swiper-slide">Slide 5</div>
-          <div class="swiper-slide">Slide 6</div>
-        </div>
-
-        <!-- If we need scrollbar -->
-        <div class="swiper-scrollbar"></div>
-
-        <!-- If we need pagination -->
-        <div class="swiper-pagination"></div>
-
-        <!-- If we need navigation buttons -->
-        <div class="swiper-button-prev"></div>
-        <div class="swiper-button-next"></div>
-      </div>
+      ${SwiperTemplate()}
     `;
   },
   play: async () => {
@@ -72,7 +88,6 @@ export const LargeCards = {
 };
 
 export const MiniCards = {
-  args: {},
   decorators: [
     (story) =>
       html`
@@ -84,34 +99,12 @@ export const MiniCards = {
         ${story()}
       `,
   ],
-  render: (args) => {
+  render: () => {
     return html`
       This example sets a fixed width on each slide.
       <br /><br />
 
-      <!-- Slider main container -->
-      <div class="swiper">
-        <!-- Additional required wrapper -->
-        <div class="swiper-wrapper">
-          <!-- Slides -->
-          <div class="swiper-slide">Slide 1</div>
-          <div class="swiper-slide">Slide 2</div>
-          <div class="swiper-slide">Slide 3</div>
-          <div class="swiper-slide">Slide 4</div>
-          <div class="swiper-slide">Slide 5</div>
-          <div class="swiper-slide">Slide 6</div>
-        </div>
-
-        <!-- If we need scrollbar -->
-        <div class="swiper-scrollbar"></div>
-
-        <!-- If we need pagination -->
-        <div class="swiper-pagination"><a>test</a></div>
-
-        <!-- If we need navigation buttons -->
-        <div class="swiper-button-prev"></div>
-        <div class="swiper-button-next"></div>
-      </div>
+      ${SwiperTemplate()}
     `;
   },
   play: async () => {
@@ -120,71 +113,30 @@ export const MiniCards = {
 };
 
 export const FullBleed = {
-  args: {},
-  render: (args) => {
+  render: () => {
     return html`
       This example adds the "swiper-full-bleed" class to extend beyond the page
       gutter to the edge of the screen.
       <br /><br />
 
-      <!-- Slider main container -->
-      <div class="swiper swiper-full-bleed">
-        <!-- Additional required wrapper -->
-        <div class="swiper-wrapper">
-          <!-- Slides -->
-          <div class="swiper-slide">Slide 1</div>
-          <div class="swiper-slide">Slide 2</div>
-          <div class="swiper-slide">Slide 3</div>
-          <div class="swiper-slide">Slide 4</div>
-          <div class="swiper-slide">Slide 5</div>
-          <div class="swiper-slide">Slide 6</div>
-        </div>
-
-        <!-- If we need scrollbar -->
-        <div class="swiper-scrollbar"></div>
-
-        <!-- If we need pagination -->
-        <div class="swiper-pagination"></div>
-
-        <!-- If we need navigation buttons -->
-        <div class="swiper-button-prev"></div>
-        <div class="swiper-button-next"></div>
-      </div>
+      ${SwiperTemplate()}
     `;
   },
   play: async () => {
+    document.querySelector('.swiper').classList.add('swiper-full-bleed');
+
     new Swiper('.swiper', SwiperConfig);
   },
 };
 
 export const PaginationBullets = {
-  args: {},
-  render: (args) => {
+  render: () => {
     return html`
       This example extends the Shidoka default Swiper config to use the
       "bullets" style of pagination instead of "fractional".
       <br /><br />
 
-      <!-- Slider main container -->
-      <div class="swiper">
-        <!-- Additional required wrapper -->
-        <div class="swiper-wrapper">
-          <!-- Slides -->
-          <div class="swiper-slide">Slide 1</div>
-          <div class="swiper-slide">Slide 2</div>
-          <div class="swiper-slide">Slide 3</div>
-          <div class="swiper-slide">Slide 4</div>
-          <div class="swiper-slide">Slide 5</div>
-          <div class="swiper-slide">Slide 6</div>
-        </div>
-
-        <!-- If we need pagination -->
-        <div class="swiper-pagination"></div>
-
-        <!-- If we need navigation buttons -->
-        <div class="swiper-button-prev"></div>
-        <div class="swiper-button-next"></div>
-      </div>
+      ${SwiperTemplate()}
     `;
   },
   play: async () => {
@@ -200,8 +152,7 @@ export const PaginationBullets = {
 };
 
 export const PaginationTabs = {
-  args: {},
-  render: (args) => {
+  render: () => {
     return html`
       This example extends the Shidoka default Swiper config to modify the
       "bullets" style of pagination to convert them to Tabs on larger screen
@@ -209,28 +160,12 @@ export const PaginationTabs = {
       should be limited to 5.
       <br /><br />
 
-      <!-- Slider main container -->
-      <div class="swiper">
-        <!-- Additional required wrapper -->
-        <div class="swiper-wrapper">
-          <!-- Slides -->
-          <div class="swiper-slide">Slide 1</div>
-          <div class="swiper-slide">Slide 2</div>
-          <div class="swiper-slide">Slide 3</div>
-          <div class="swiper-slide">Slide 4</div>
-          <div class="swiper-slide">Slide 5</div>
-        </div>
-
-        <!-- If we need pagination -->
-        <div class="swiper-pagination tabs"></div>
-
-        <!-- If we need navigation buttons -->
-        <div class="swiper-button-prev"></div>
-        <div class="swiper-button-next"></div>
-      </div>
+      ${SwiperTemplate(5)}
     `;
   },
   play: async () => {
+    document.querySelector('.swiper-pagination').classList.add('tabs');
+
     const TabTextArr = ['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4', 'Tab 5'];
 
     const CustomConfig = {
@@ -253,35 +188,12 @@ export const PaginationTabs = {
 };
 
 export const WithLink = {
-  args: {},
-  render: (args) => {
+  render: () => {
     return html`
       This example injects a link into the fractional pagination.
       <br /><br />
 
-      <!-- Slider main container -->
-      <div class="swiper">
-        <!-- Additional required wrapper -->
-        <div class="swiper-wrapper">
-          <!-- Slides -->
-          <div class="swiper-slide">Slide 1</div>
-          <div class="swiper-slide">Slide 2</div>
-          <div class="swiper-slide">Slide 3</div>
-          <div class="swiper-slide">Slide 4</div>
-          <div class="swiper-slide">Slide 5</div>
-          <div class="swiper-slide">Slide 6</div>
-        </div>
-
-        <!-- If we need scrollbar -->
-        <div class="swiper-scrollbar"></div>
-
-        <!-- If we need pagination -->
-        <div class="swiper-pagination"></div>
-
-        <!-- If we need navigation buttons -->
-        <div class="swiper-button-prev"></div>
-        <div class="swiper-button-next"></div>
-      </div>
+      ${SwiperTemplate()}
     `;
   },
   play: async () => {

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -194,10 +194,6 @@ export const WithLink = {
       This example places a link inline with the fractional pagination.
       <br /><br />
 
-      <!--
-      ${SwiperTemplate()}
-      -->
-
       <!-- Slider main container -->
       <div class="swiper">
         <!-- Additional required wrapper -->
@@ -214,7 +210,7 @@ export const WithLink = {
         <!-- If we need scrollbar -->
         <div class="swiper-scrollbar"></div>
 
-        <!-- If we need pagination -->
+        <!-- If we need a link next to pagination -->
         <div class="pagination-with-link">
           <div class="swiper-pagination"></div>
 


### PR DESCRIPTION
## Summary

Added Shidoka default configuration and stylesheet for [Swiper](https://swiperjs.com/), with example Stories and usage documentation.

## ADO Story Link

https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/1904441/

## Figma Link

https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/Applications---Component-Library?node-id=16511-29991&node-type=frame&m=dev

**Note:** Some things have been tweaked slightly and are not reflected in Figma yet. Notably:
- Fractional paging
- Tab styles
- Off-screen slide de-saturation
