### PR TITLE
fix(tags,notificaiton): Minor accessiblity updates for tags and notificaiton components

### DIFF
--- a/src/components/reusable/notification/notification.scss
+++ b/src/components/reusable/notification/notification.scss
@@ -124,7 +124,7 @@ kd-card.notification-mark-read::part(card-wrapper) {
     margin-left: 8px;
   }
   &-text {
-    @include typography.type-ui-03;
+    @include typography.type-ui-02;
     color: var(--kd-color-text-primary);
     font-weight: 500;
   }

--- a/src/components/reusable/notification/notificationContainer.scss
+++ b/src/components/reusable/notification/notificationContainer.scss
@@ -1,4 +1,5 @@
 @use '../../../common/scss/global.scss';
+
 :host {
   display: block;
 }

--- a/src/components/reusable/tag/tag.scss
+++ b/src/components/reusable/tag/tag.scss
@@ -7,7 +7,7 @@
 }
 
 .tags {
-  @include typography.type-ui-03;
+  @include typography.type-ui-02;
   display: flex;
   align-items: center;
   justify-content: space-around;


### PR DESCRIPTION
## Summary

Changed the type mixin for tag text and notification's timeStamp text to have `font-size: 14px`.

## ADO Story or GitHub Issue Link

[TASK 1907198](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/1907198)

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [x] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots
<img width="1724" alt="Screenshot 2024-09-24 at 8 40 04 PM" src="https://github.com/user-attachments/assets/0963ca0b-fe05-47c6-9725-29d70200355e">
<img width="1727" alt="Screenshot 2024-09-24 at 8 40 38 PM" src="https://github.com/user-attachments/assets/32204b56-15c1-4903-a90a-5c6384e1d96f">

