### PR TITLE
fix(tabs): transparent background instead of white

### DIFF
--- a/src/components/reusable/tabs/tab.scss
+++ b/src/components/reusable/tabs/tab.scss
@@ -25,7 +25,7 @@
   white-space: nowrap;
   text-align: center;
   border-bottom: 2px solid var(--kd-color-border-default);
-  background: var(--kd-color-background-ui-default);
+  background: transparent;
   transition: border-color 150ms ease-out, background-color 150ms ease-out,
     color 150ms ease-out;
 
@@ -99,7 +99,7 @@
     }
 
     &.contained {
-      background: var(--kd-color-background-ui-default);
+      background: transparent;
       border-color: var(--kd-color-border-tertiary);
 
       &:hover {
@@ -114,7 +114,7 @@
     border-color: var(--kd-color-border-ui-disabled);
 
     &:hover {
-      background: var(--kd-color-background-ui-default);
+      background: transparent;
     }
 
     &.contained {


### PR DESCRIPTION
## Summary

Adjust Tabs background color to be transparent so it can be used on light-gray backgrounds as well as white. 

Changes include:

- Line style default BG
- Line style disabled:hover BG
- Contained style selected/active BG