### PR TITLE
feat: first globalFilter acc open by default, lock rightmost data table col

### DIFF
--- a/src/components/reusable/globalFilter/globalFilter.chart.sample.ts
+++ b/src/components/reusable/globalFilter/globalFilter.chart.sample.ts
@@ -33,6 +33,10 @@ export class SampleFilterChartComponent extends LitElement {
     }
   `;
 
+  /** Sets whether the first accordion item should be expanded by default */
+  @property({ type: Boolean })
+  firstExpanded = false;
+
   /** Array of sample checkbox filter options. */
   @property({ type: Array })
   checkboxOptions: Array<any> = [
@@ -140,7 +144,7 @@ export class SampleFilterChartComponent extends LitElement {
           </kd-button>
 
           <kd-accordion filledHeaders compact>
-            <kd-accordion-item>
+            <kd-accordion-item ?opened=${this.firstExpanded}>
               <span slot="title">
                 Colors:
                 ${SelectedOptions.length

--- a/src/components/reusable/globalFilter/globalFilter.sample.ts
+++ b/src/components/reusable/globalFilter/globalFilter.sample.ts
@@ -18,6 +18,12 @@ import filterEditIcon from '@carbon/icons/es/filter--edit/20';
 import filterRemoveIcon from '@carbon/icons/es/close--filled/16';
 import refreshIcon from '@carbon/icons/es/renew/20';
 
+interface CheckboxOption {
+  value: string;
+  text: string;
+  checked?: boolean;
+}
+
 /**  Sample Lit component to show global filter pattern. */
 @customElement('sample-filter-component')
 export class SampleFilterComponent extends LitElement {
@@ -33,9 +39,13 @@ export class SampleFilterComponent extends LitElement {
     }
   `;
 
+  /** Sets whether the first accordion item should be expanded by default */
+  @property({ type: Boolean })
+  firstExpanded = false;
+
   /** Array of sample checkbox filter options. */
   @property({ type: Array })
-  checkboxOptions: Array<any> = [
+  checkboxOptions: CheckboxOption[] = [
     {
       value: '1',
       text: 'Option 1',
@@ -99,7 +109,7 @@ export class SampleFilterComponent extends LitElement {
           </kd-button>
 
           <kd-accordion filledHeaders compact>
-            <kd-accordion-item>
+            <kd-accordion-item ?opened=${this.firstExpanded}>
               <span slot="title">
                 Filter 1:
                 ${SelectedOptions.length
@@ -122,7 +132,7 @@ export class SampleFilterComponent extends LitElement {
                   <span slot="label">Filter 1</span>
 
                   ${this.checkboxOptions.map(
-                    (option: any) => html`
+                    (option: CheckboxOption) => html`
                       <kyn-checkbox value=${option.value}>
                         ${option.text}
                       </kyn-checkbox>
@@ -227,7 +237,7 @@ export class SampleFilterComponent extends LitElement {
     }
   }
 
-  private _handleTagClick(e: any, option: any) {
+  private _handleTagClick(e: any, option: CheckboxOption) {
     action(e.type)(e);
     // console.log(e.detail);
 
@@ -266,6 +276,7 @@ export class SampleFilterComponent extends LitElement {
     // overflow link click logic here
   }
 }
+
 declare global {
   interface HTMLElementTagNameMap {
     'sample-filter-component': SampleFilterComponent;

--- a/src/components/reusable/globalFilter/globalFilter.stories.js
+++ b/src/components/reusable/globalFilter/globalFilter.stories.js
@@ -18,7 +18,7 @@ export default {
 export const GlobalFilter = {
   render: () => {
     return html`
-      <sample-filter-component></sample-filter-component>
+      <sample-filter-component firstExpanded></sample-filter-component>
 
       <br />
 
@@ -64,7 +64,9 @@ export const WithChart = {
   },
   render: () => {
     return html`
-      <sample-filter-chart-component></sample-filter-chart-component>
+      <sample-filter-chart-component
+        firstExpanded
+      ></sample-filter-chart-component>
 
       <br />
 
@@ -86,7 +88,9 @@ export const WithChart = {
 export const WithTable = {
   render: () => {
     return html`
-      <sample-filter-table-component></sample-filter-table-component>
+      <sample-filter-table-component
+        firstExpanded
+      ></sample-filter-table-component>
       <br />
 
       <p>

--- a/src/components/reusable/globalFilter/globalFilter.table.sample.ts
+++ b/src/components/reusable/globalFilter/globalFilter.table.sample.ts
@@ -1,5 +1,5 @@
 import { html, css, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { action } from '@storybook/addon-actions';
 import { repeat } from 'lit/directives/repeat.js';
 
@@ -20,7 +20,13 @@ import filterEditIcon from '@carbon/icons/es/filter--edit/20';
 import filterRemoveIcon from '@carbon/icons/es/close--filled/16';
 import refreshIcon from '@carbon/icons/es/renew/20';
 
-/**  Sample Lit component to show global filter pattern applied to a Chart. */
+interface CheckboxOption {
+  value: string;
+  text: string;
+  checked?: boolean;
+}
+
+/**  Sample Lit component to show global filter pattern applied to a Table. */
 @customElement('sample-filter-table-component')
 export class SampleFilterTableComponent extends LitElement {
   static override styles = css`
@@ -35,9 +41,13 @@ export class SampleFilterTableComponent extends LitElement {
     }
   `;
 
+  /** Sets whether the first accordion item should be expanded by default */
+  @property({ type: Boolean })
+  firstExpanded = false;
+
   /** Array of sample checkbox filter options. */
   @state()
-  checkboxOptions: Array<any> = [
+  checkboxOptions: CheckboxOption[] = [
     {
       value: 'Stark',
       text: 'Stark',
@@ -53,10 +63,10 @@ export class SampleFilterTableComponent extends LitElement {
   ];
 
   @state()
-  houses: Array<string> = ['Stark', 'Lannister', 'Targaryen'];
+  houses: string[] = ['Stark', 'Lannister', 'Targaryen'];
 
   @state()
-  filteredHouses: Array<string> = [];
+  filteredHouses: string[] = [];
 
   @state()
   private characters = [
@@ -83,7 +93,7 @@ export class SampleFilterTableComponent extends LitElement {
   ];
 
   @state()
-  selectedRows = [];
+  selectedRows: any[] = [];
 
   @state()
   opened = false;
@@ -92,10 +102,6 @@ export class SampleFilterTableComponent extends LitElement {
     this.opened = !this.opened;
   }
 
-  /**
-   * kynTable: Reference to the kyn-table component.
-   * @ignore
-   */
   @state()
   private kynTable: any;
 
@@ -140,7 +146,7 @@ export class SampleFilterTableComponent extends LitElement {
           </kd-button>
 
           <kd-accordion filledHeaders compact>
-            <kd-accordion-item>
+            <kd-accordion-item ?opened=${this.firstExpanded}>
               <span slot="title">
                 Houses:
                 ${SelectedOptions.length
@@ -163,7 +169,7 @@ export class SampleFilterTableComponent extends LitElement {
                   <span slot="label">Filter 1</span>
 
                   ${this.checkboxOptions.map(
-                    (option: any) => html`
+                    (option: CheckboxOption) => html`
                       <kyn-checkbox value=${option.value}>
                         ${option.text}
                       </kyn-checkbox>

--- a/src/components/reusable/globalFilter/globalFilter.ts
+++ b/src/components/reusable/globalFilter/globalFilter.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import GlobalFilterScss from './globalFilter.scss';
 
 /**
@@ -11,6 +11,10 @@ import GlobalFilterScss from './globalFilter.scss';
 @customElement('kyn-global-filter')
 export class GlobalFilter extends LitElement {
   static override styles = GlobalFilterScss;
+
+  /** Sets whether the first accordion item should be expanded by default */
+  @property({ type: Boolean })
+  firstExpanded = false;
 
   override render() {
     return html`


### PR DESCRIPTION
## Summary

Enhancements:
✅ 1. Add `firstExpanded` property to globalFilter component to expand first accordion item by default 
 2. Lock right-most column in data table

## ADO Story or GitHub Issue Link

N/A

## Figma Link

[Global Filter](https://shidoka-applications.netlify.app/?path=/story/patterns-global-filter--with-table)

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Testing Instructions

View Global Filter changes in `patterns/Global Filter`

## Screenshots

<img width="1295" alt="Screenshot 2024-11-04 at 1 16 44 PM" src="https://github.com/user-attachments/assets/527fd676-f9d7-4f5d-88ac-cb0580db107e">

