### PR TITLE
fix(header): alignment of logo when nav menu is absent

### DIFF
--- a/src/components/global/header/header.scss
+++ b/src/components/global/header/header.scss
@@ -17,7 +17,7 @@
   height: var(--kd-header-height);
   background: var(--kd-color-neutral-webgray);
   box-shadow: 0px 3px 3px 0px rgba(0, 0, 0, 0.1);
-  padding: 4px var(--kd-page-gutter);
+  padding: 4px calc(var(--kd-page-gutter) - 4px) 4px var(--kd-page-gutter);
   transition: z-index 150ms ease-out;
   z-index: var(--kd-z-header);
 

--- a/src/components/global/header/header.scss
+++ b/src/components/global/header/header.scss
@@ -9,6 +9,7 @@
 .header {
   display: flex;
   align-items: center;
+  gap: 16px;
   position: fixed;
   top: 0;
   right: 0;
@@ -16,7 +17,7 @@
   height: var(--kd-header-height);
   background: var(--kd-color-neutral-webgray);
   box-shadow: 0px 3px 3px 0px rgba(0, 0, 0, 0.1);
-  padding: 4px 12px 4px 16px;
+  padding: 4px var(--kd-page-gutter);
   transition: z-index 150ms ease-out;
   z-index: var(--kd-z-header);
 
@@ -43,7 +44,7 @@
 .logo-link {
   display: flex;
   align-items: center;
-  margin-left: 16px;
+  // margin-left: 16px;
   // color: var(--kd-color-text-link);
   text-decoration: none;
 

--- a/src/components/global/localNav/localNav.scss
+++ b/src/components/global/localNav/localNav.scss
@@ -123,7 +123,7 @@ nav {
   outline-offset: -2px;
   font: inherit;
   color: var(--kd-color-text-secondary);
-  padding: 8px;
+  padding: 8px 12px;
   cursor: pointer;
   display: flex;
   align-items: center;

--- a/src/components/global/localNav/localNav.scss
+++ b/src/components/global/localNav/localNav.scss
@@ -123,7 +123,7 @@ nav {
   outline-offset: -2px;
   font: inherit;
   color: var(--kd-color-text-secondary);
-  padding: 8px 12px;
+  padding: 8px;
   cursor: pointer;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Corrected an alignment issue where the Header logo had too much space on the left side when the nav menu was absent, particularly at mobile sizes.

[Initial report reference link](https://teams.microsoft.com/l/message/19:m15yXA3kC7fl9TvnIML-6DxhfDtwyoLJMu0nVAeddXQ1@thread.tacv2/1730837559654?tenantId=f260df36-bc43-424c-8f44-c85226657b01&groupId=6097bcb7-eb77-4588-9226-1430b9c803ab&parentMessageId=1730837559654&teamName=Shidoka%20Design%20System&channelName=General&createdTime=1730837559654)
