### PR TITLE
fix: disabled input hover & icon color

### DIFF
--- a/src/common/scss/form-input.scss
+++ b/src/common/scss/form-input.scss
@@ -51,15 +51,6 @@ textarea {
   outline: 2px solid transparent;
   outline-offset: 2px;
 
-  &[invalid] {
-    border-color: var(--kd-color-border-error);
-  }
-
-  &[disabled] {
-    color: var(--kd-color-text-disabled);
-    border-color: var(--kd-color-border-ui-disabled);
-  }
-
   &:hover {
     border-color: var(--kd-color-border-ui-hover);
   }
@@ -70,6 +61,15 @@ textarea {
 
   &::placeholder {
     color: var(--kd-color-text-placeholder);
+  }
+
+  &[invalid] {
+    border-color: var(--kd-color-border-error);
+  }
+
+  &[disabled] {
+    color: var(--kd-color-text-disabled);
+    border-color: var(--kd-color-border-ui-disabled);
   }
 }
 

--- a/src/components/reusable/textInput/textInput.scss
+++ b/src/components/reusable/textInput/textInput.scss
@@ -27,6 +27,10 @@
 
 slot[name='icon']::slotted(*) {
   display: block;
+
+  [disabled] & {
+    color: var(--kd-color-text-disabled);
+  }
 }
 
 input {


### PR DESCRIPTION
## Summary

Fixed the disabled form input styles so the border color doesn't change on hover, and the text input icon uses the disabled text color.
