### PR TITLE
fix(dropdown): disable clear button correctly

### DIFF
--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -184,6 +184,11 @@
   display: block;
   color: var(--kd-color-text-primary);
 
+  &[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
   kd-icon {
     display: block;
   }

--- a/src/components/reusable/dropdown/dropdown.ts
+++ b/src/components/reusable/dropdown/dropdown.ts
@@ -352,6 +352,7 @@ export class Dropdown extends FormMixin(LitElement) {
                 <button
                   class="clear"
                   aria-label="Clear search text"
+                  ?disabled=${this.disabled}
                   @click=${(e: any) => this.handleClear(e)}
                 >
                   <kd-icon .icon=${clearIcon}></kd-icon>


### PR DESCRIPTION
## Summary

Resolves #289. 
Clear button (X) will now appear disabled and will not be clickable.