### PR TITLE
fix(formTextInput): updated caption and icon color token

### DIFF
--- a/src/common/scss/form-input.scss
+++ b/src/common/scss/form-input.scss
@@ -143,10 +143,10 @@ textarea {
 .caption {
   margin-top: 8px;
   cursor: default;
-  color: var(--kd-color-text-forms-label-secondary);
+  color: var(--kd-color-text-forms-input-field-text);
 
   [disabled] & {
-    color: var(--kd-color-text-link-level-disabled);
+    color: var(--kd-color-text-level-disabled);
   }
 }
 

--- a/src/components/reusable/textInput/textInput.scss
+++ b/src/components/reusable/textInput/textInput.scss
@@ -29,7 +29,7 @@ slot[name='icon']::slotted(*) {
   display: block;
 
   [disabled] & {
-    color: var(--kd-color-text-link-level-disabled);
+    color: var(--kd-color-icon-disabled);
   }
 }
 


### PR DESCRIPTION
## Note

**kd-color--text-level-disabled**  currently not exists in foundation.

## Summary

Text Input caption and Icon disabled state color token updated

## ADO Issue

https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2041670

## Figma Link

https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/branch/qMpff4GuFUEcsMUkvacS3U/Applications---Component-Library?node-id=4291-236773&m=dev


## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

