### PR TITLE
feat(progress bar): colour token updates

### DIFF
--- a/src/components/reusable/progressBar/progressBar.scss
+++ b/src/components/reusable/progressBar/progressBar.scss
@@ -4,16 +4,18 @@
 @use '~@kyndryl-design-system/shidoka-foundation/scss/mixins/visibility.scss';
 
 $progress-bar-status-colors: (
-  default: var(--kd-color-background-primary-hover),
-  success: var(--kd-color-background-success),
-  error: var(--kd-color-background-error),
+  default: var(--kd-color-background-loader-bar-primary),
+  success: var(--kd-color-status-success-dark),
+  error: var(--kd-color-status-error-dark),
 );
 
 $progress-bar-height: 4px;
 $progress-bar-radius: 4px;
-$progress-bar-background: var(--kd-color-background-inverse-hover);
-$progress-bar-indeterminate-color: map-get($progress-bar-status-colors,
-    default);
+$progress-bar-background: var(--kd-color-background-loader-bar-secondary);
+$progress-bar-indeterminate-color: map-get(
+  $progress-bar-status-colors,
+  default
+);
 
 @mixin progress-bar-color($color) {
   background-color: $color;
@@ -55,7 +57,6 @@ $progress-bar-indeterminate-color: map-get($progress-bar-status-colors,
     margin: 0;
     line-height: 16px;
     height: 16px;
-    color: var(--kd-color-text-level-secondary);
   }
 
   &__status-icon {
@@ -63,6 +64,18 @@ $progress-bar-indeterminate-color: map-get($progress-bar-status-colors,
     align-items: center;
     padding-right: 2px;
     line-height: 1;
+
+    .success-icon {
+      svg {
+        fill: map-get($progress-bar-status-colors, success);
+      }
+    }
+
+    .error-icon {
+      svg {
+        fill: map-get($progress-bar-status-colors, error);
+      }
+    }
 
     p {
       color: var(--kd-color-text-level-secondary);
@@ -117,7 +130,9 @@ $progress-bar-indeterminate-color: map-get($progress-bar-status-colors,
       width: 55px;
       position: absolute;
       left: 0;
-      @include progress-bar-color(map-get($progress-bar-status-colors, default));
+      @include progress-bar-color(
+        map-get($progress-bar-status-colors, default)
+      );
       animation: indeterminate 3s ease-in-out infinite;
     }
 
@@ -136,6 +151,15 @@ $progress-bar-indeterminate-color: map-get($progress-bar-status-colors,
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
+}
+
+.active,
+.success {
+  color: var(--kd-color-text-level-secondary);
+}
+
+.error {
+  color: var(--kd-color-status-error-dark);
 }
 
 @keyframes indeterminate {


### PR DESCRIPTION
## Summary

Updated colour tokens as per the UX.

## ADO Story or GitHub Issue Link

[TASK 2003578](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2003578)

## Figma Link

[Progress bar](https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/branch/qMpff4GuFUEcsMUkvacS3U/Applications---Component-Library?node-id=19723-26651&node-type=canvas&m=dev)

## Notes

Updated the colour tokens for the following components

- Progress bar

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file
