### PR TITLE
fix(TextInput): icon right with clear icon fix

### DIFF
--- a/src/components/reusable/textInput/textInput.scss
+++ b/src/components/reusable/textInput/textInput.scss
@@ -20,6 +20,14 @@
     right: 16px;
   }
 
+  &.icon--right .clear {
+    right: 45px;
+  }
+
+  &.icon--right input {
+    padding-right: 72px;
+  }
+
   &.icon--left input {
     padding-left: 48px;
   }

--- a/src/components/reusable/textInput/textInput.scss
+++ b/src/components/reusable/textInput/textInput.scss
@@ -20,7 +20,8 @@
     right: 16px;
   }
 
-  &.icon--right .clear {
+  &.icon--right .clear,
+  &.icon--right .error-icon {
     right: 45px;
   }
 


### PR DESCRIPTION
## Summary

Display right icon with clear icon

## GitHub Issue Link

https://github.com/kyndryl-design-system/shidoka-applications/issues/304



## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## Screenshots


<img width="851" alt="image" src="https://github.com/user-attachments/assets/b019c500-d1e0-4075-ae2d-6f62e26b12e5" />

