### PR TITLE
fix(Dropdown): disable state fix

### DIFF
--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -75,11 +75,16 @@
     background-color: transparent;
 
     &:hover {
-
       [disabled] & {
         border-color: transparent;
       }
     }
+  }
+  &[disabled] {
+    background: var(--kd-color-background-ui-hollow-default);
+    border-color: var(--kd-color-border-ui-disabled);
+    color: var(--kd-color-text-link-level-disabled);
+    cursor: default;
   }
 }
 
@@ -161,10 +166,20 @@
   display: flex;
 }
 
+.error.disabled {
+  color: var(--kd-color-text-level-disabled);
+  span svg {
+    color: var(--kd-color-text-link-level-disabled);
+  }
+}
+
 .caption {
   [inline] & {
     margin-left: 16px;
   }
+}
+.caption.disabled {
+  color: var(--kd-color-text-level-disabled);
 }
 
 .assistive-text {

--- a/src/components/reusable/dropdown/dropdown.ts
+++ b/src/components/reusable/dropdown/dropdown.ts
@@ -235,13 +235,17 @@ export class Dropdown extends FormMixin(LitElement) {
         }
         ${
           this.caption !== ''
-            ? html` <div class="caption">${this.caption}</div> `
+            ? html`
+                <div class="caption ${this.disabled ? 'disabled' : ''}">
+                  ${this.caption}
+                </div>
+              `
             : null
         }
         ${
           this._isInvalid
             ? html`
-                <div class="error">
+                <div class="error ${this.disabled ? 'disabled' : ''}">
                   <span
                     class="error-info-icon"
                     role="img"


### PR DESCRIPTION
## Summary

Dropdown Disable state : Placeholder, caption and invalid text are not grayed out

## ADO Issue Link

[BUG 2089084](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2089084)

## Figma Link

NA


## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## Screenshots

<img width="769" alt="image" src="https://github.com/user-attachments/assets/c428e2eb-c848-4b6d-8220-6c145efc83e3" />
