### PR TITLE
feat: card with title tooltip pattern

### DIFF
--- a/src/stories/sampleCardComponents/vitalCard.sample.ts
+++ b/src/stories/sampleCardComponents/vitalCard.sample.ts
@@ -3,6 +3,7 @@ import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import vitalCardScss from './vitalCard.scss';
 import '../../components/reusable/link';
+import '../../components/reusable/tooltip';
 
 import chevronRightIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/chevron-right.svg';
 import '../../components/reusable/loaders/skeleton';
@@ -16,6 +17,10 @@ export class VitalCardSampleComponent extends LitElement {
   @property({ type: Boolean })
   skeleton = false;
 
+  /** show tooltip */
+  @property({ type: Boolean })
+  showTooltip = false;
+
   override render() {
     return html`
       <div>
@@ -23,6 +28,9 @@ export class VitalCardSampleComponent extends LitElement {
           ${this.skeleton
             ? html`<kyn-skeleton lines="1" inline></kyn-skeleton>`
             : 'Title'}
+          ${this.showTooltip
+            ? html`<kyn-tooltip>Tooltip content</kyn-tooltip>`
+            : null}
         </div>
         <div class="vital-card-content-wrapper">
           <div class="vital-card-mobile-wrapper-subdiv">

--- a/src/stories/sampleCardComponents/vitalCard.scss
+++ b/src/stories/sampleCardComponents/vitalCard.scss
@@ -8,6 +8,8 @@
     @include typography.type-body-02;
     color: var(--kd-color-text-level-secondary);
     margin-bottom: 8px;
+    display: flex;
+    gap: 8px;
   }
 
   &-title {
@@ -16,6 +18,7 @@
     margin-top: 0px;
     margin-bottom: 0px;
     color: var(--kd-color-text-level-primary);
+
     // for large device after md size
     @media (min-width: 42rem) {
       @include typography.type-headline-07;
@@ -42,6 +45,7 @@
   &-mobile-wrapper-subdiv {
     display: flex;
     align-items: center;
+
     @media (min-width: 42rem) {
       display: block;
     }
@@ -53,23 +57,29 @@
     margin-top: 0px;
     margin-bottom: 0px;
   }
+
   &-subcategory-text {
     @include typography.type-ui-03;
     color: var(--kd-color-text-level-secondary);
     margin-top: 0;
     margin-bottom: 4px;
   }
+
   &-cat-subcat-text {
     padding: 0px 8px;
+
     @media (min-width: 42rem) {
       padding: 0;
     }
   }
+
   &-link {
     margin-top: 0px;
+
     @media (min-width: 42rem) {
       margin-top: 10px;
     }
+
     &-text {
       @media (max-width: calc(42rem - 1px)) {
         @include visibility.sr-only;

--- a/src/stories/vitalCard.stories.js
+++ b/src/stories/vitalCard.stories.js
@@ -24,9 +24,19 @@ const args = {
 
 export const Default = {
   render: () => {
-    return html`<kyn-card type="normal">
-      <vital-card-sample-component></vital-card-sample-component>
-    </kyn-card>`;
+    return html`
+      <h4 style="margin-bottom: 4px">Default card</h4>
+      <kyn-card type="normal">
+        <vital-card-sample-component></vital-card-sample-component>
+      </kyn-card>
+      <br /><br />
+      <h4 style="margin-bottom: 4px">Card with tooltip</h4>
+      <kyn-card type="normal">
+        <vital-card-sample-component
+          ?showtooltip=${true}
+        ></vital-card-sample-component>
+      </kyn-card>
+    `;
   },
 };
 


### PR DESCRIPTION
## Summary

Fixes [AB#2102137](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2102137)

Added a card pattern which has tooltip(info icon) along with title.

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots

<img width="306" alt="image" src="https://github.com/user-attachments/assets/2ac29930-9b27-4131-826e-a10a2caf230f" />

