### PR TITLE
fix(accordion): subtitle accessibility

### DIFF
--- a/src/components/reusable/accordion/accordionItem.scss
+++ b/src/components/reusable/accordion/accordionItem.scss
@@ -123,7 +123,7 @@
 .kyn-accordion-item-subtitle {
   @include typography.type-ui-02;
   font-weight: var(--kd-font-weight-regular);
-  color: var(--kd-color-text-level-secondary);
+  color: var(--kd-color-text-level-primary);
 
   .disabled & {
     color: var(--kd-color-text-link-level-disabled);


### PR DESCRIPTION
## Summary

Accordion
- changed the subtitle colour token to `text-level-primary`

## Notes

Changes done as per - [2.0 color test](https://kyndryl-my.sharepoint.com/:x:/r/personal/brian_patrick3_kyndryl_com/_layouts/15/doc2.aspx?sourcedoc=%7Bb1d2f480-e50c-4442-8e85-18e65341e603%7D&action=edit&activeCell=%27Sheet1%27!I16&wdinitialsession=0af86b70-9e65-1016-d1ac-446ed40feca7&wdrldsc=4&wdrldc=1&wdrldr=AccessTokenExpiredWarningGatekeeperCookieMismatch%2C)

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/17cde09a-178c-47b6-a475-2878558939b4" />
