### PR TITLE
fix(issue-372): event propagation fix for table row selection events

### DIFF
--- a/src/components/reusable/table/story-helpers/table-story.sample.ts
+++ b/src/components/reusable/table/story-helpers/table-story.sample.ts
@@ -195,7 +195,6 @@ class MyStoryTable extends LitElement {
   }
 
   handleSelectedRowsChange(e: CustomEvent) {
-    e.stopPropagation();
     action(e.type)(e);
     const { selectedRows } = e.detail;
     this.selectedRows = selectedRows;

--- a/src/components/reusable/table/story-helpers/table-story.sample.ts
+++ b/src/components/reusable/table/story-helpers/table-story.sample.ts
@@ -195,6 +195,7 @@ class MyStoryTable extends LitElement {
   }
 
   handleSelectedRowsChange(e: CustomEvent) {
+    e.stopPropagation();
     action(e.type)(e);
     const { selectedRows } = e.detail;
     this.selectedRows = selectedRows;

--- a/src/components/reusable/table/table.ts
+++ b/src/components/reusable/table/table.ts
@@ -210,7 +210,7 @@ export class Table extends LitElement {
     this._updateHeaderCheckbox();
 
     const init = {
-      bubbles: true,
+      bubbles: false,
       cancelable: true,
       composed: true,
       detail: {
@@ -249,7 +249,7 @@ export class Table extends LitElement {
     this._updateHeaderCheckbox();
 
     const init = {
-      bubbles: true,
+      bubbles: false,
       cancelable: true,
       composed: true,
       detail: {


### PR DESCRIPTION
## ADO Story or GitHub Issue Link

fixes #372

## Notes

- Set `bubbles: false` on row selection events to avoid passing of the event to it's parent in case of [Nested table](https://shidoka-applications.netlify.app/?path=/story/components-data-table--nested-table)

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file
