### PR TITLE
fix(button): colour token changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@kyndryl-design-system/shidoka-applications",
       "version": "0.0.0-semantic-release",
       "dependencies": {
-        "@kyndryl-design-system/shidoka-foundation": "^2.2.0",
+        "@kyndryl-design-system/shidoka-foundation": "^2.2.1",
         "@kyndryl-design-system/shidoka-icons": "^2.0.0",
         "@lit/context": "^1.1.0",
         "deepmerge-ts": "^7.1.0",
@@ -3794,9 +3794,9 @@
       }
     },
     "node_modules/@kyndryl-design-system/shidoka-foundation": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-2.2.0.tgz",
-      "integrity": "sha512-Y9UFXG7NXboAgR7kGP+W8o2LPLtP6HDpMFVFX9eDqWhmgDUwKKNjBupXXjSl6R1vE+usnKQ4lE9UNgdPsbRREA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-2.2.1.tgz",
+      "integrity": "sha512-ek3R8yIY48Kn4QXUmCilR4lp7l7SUbts/VoE7FkRxUvBy2cVhh1HSmyfuoCs0AWXIjDGN0g00v68f9vbsx/ehw=="
     },
     "node_modules/@kyndryl-design-system/shidoka-icons": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepare": "npx husky install"
   },
   "dependencies": {
-    "@kyndryl-design-system/shidoka-foundation": "^2.2.0",
+    "@kyndryl-design-system/shidoka-foundation": "^2.2.1",
     "@kyndryl-design-system/shidoka-icons": "^2.0.0",
     "@lit/context": "^1.1.0",
     "deepmerge-ts": "^7.1.0",

--- a/src/components/reusable/button/button.scss
+++ b/src/components/reusable/button/button.scss
@@ -118,6 +118,7 @@
       &:before {
         background-color: transparent;
       }
+
       &:hover {
         color: var(--kd-color-text-link-level-disabled);
       }
@@ -251,9 +252,7 @@
     color: var(--kd-color-text-level-primary);
 
     // hover
-    &:hover {
-      color: var(--kd-color-text-level-light);
-    }
+
     &:before {
       background-color: var(
         --kd-color-background-button-secondary-destructive-hover
@@ -261,9 +260,7 @@
     }
 
     &:focus {
-      outline-color: var(
-        --kd-color-border-button-secondary-destructive-default
-      );
+      outline-color: var(--kd-color-border-button-primary-destructive-default);
     }
 
     &:active {
@@ -285,6 +282,7 @@
     &:before {
       background-color: var(--kd-color-background-button-tertiary-state-hover);
     }
+
     &:hover {
       color: var(--kd-color-text-button-dark-primary);
     }
@@ -392,7 +390,7 @@
         --kd-color-background-button-secondary-destructive-hover
       );
       border-color: var(--kd-color-border-button-primary-destructive-hover);
-      color: var(--kd-color-text-level-light);
+      color: var(--kd-color-text-level-primary);
     }
 
     &:focus {

--- a/src/components/reusable/button/button.scss
+++ b/src/components/reusable/button/button.scss
@@ -261,6 +261,9 @@
 
     &:focus {
       outline-color: var(--kd-color-border-button-primary-destructive-default);
+      background-color: var(
+        --kd-color-background-button-secondary-destructive-hover
+      );
     }
 
     &:active {


### PR DESCRIPTION
## Summary

Changed colour token for the following:
- Secondary destructive - hover & focused state -> text and background
- Outline destructive - hover state -> text

## ADO Story or GitHub Issue Link

Fixes [AB#2124849](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2124849)

## Figma Link

[Button](https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=20904-164714&m=dev)

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file
