### PR TITLE
fix(button): remove background-color from focus

### DIFF
--- a/src/components/reusable/button/button.scss
+++ b/src/components/reusable/button/button.scss
@@ -261,9 +261,6 @@
 
     &:focus {
       outline-color: var(--kd-color-border-button-primary-destructive-default);
-      background-color: var(
-        --kd-color-background-button-secondary-destructive-hover
-      );
     }
 
     &:active {


### PR DESCRIPTION
## Summary

Removed ` background-color` from `focus ` for secondary destructive button.

## Notes

Fix for: https://github.com/kyndryl-design-system/shidoka-applications/pull/384/files/3ec6096e8d9a542bc729570ab880901fb5ef409d#r1965467261

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file
