### PR TITLE
fix(ai launch button): rename customElement name

### DIFF
--- a/src/components/ai/aiLaunchButton/aiLaunchButton.stories.js
+++ b/src/components/ai/aiLaunchButton/aiLaunchButton.stories.js
@@ -5,7 +5,7 @@ import './aiLaunchButton';
 
 export default {
   title: 'AI/Components/AI Launch Button',
-  component: 'kyn-ai-assist',
+  component: 'kyn-ai-launch-btn',
   parameters: {
     design: {
       type: 'figma',
@@ -41,10 +41,10 @@ export const Default = {
       </p>
     </div>
     <kyn-button-float-container>
-      <kyn-ai-assist
+      <kyn-ai-launch-btn
         ?disabled="${args.disabled}"
         @on-click=${() => action('on-click')()}
-      ></kyn-ai-assist>
+      ></kyn-ai-launch-btn>
     </kyn-button-float-container>
   `,
 };
@@ -70,10 +70,10 @@ export const Disabled = {
       </p>
     </div>
     <kyn-button-float-container>
-      <kyn-ai-assist
+      <kyn-ai-launch-btn
         ?disabled="${args.disabled}"
         @on-click=${() => action('on-click')()}
-      ></kyn-ai-assist>
+      ></kyn-ai-launch-btn>
     </kyn-button-float-container>
   `,
 };

--- a/src/components/ai/aiLaunchButton/aiLaunchButton.ts
+++ b/src/components/ai/aiLaunchButton/aiLaunchButton.ts
@@ -10,7 +10,7 @@ import Styles from './aiLaunchButton.scss';
  * AI Assistant Launch Button.
  * @fires on-click - Emits when the button is clicked.
  */
-@customElement('kyn-ai-assist')
+@customElement('kyn-ai-launch-btn')
 export class AILaunchButton extends LitElement {
   static override styles = Styles;
 
@@ -113,6 +113,6 @@ export class AILaunchButton extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'kyn-ai-assist': AILaunchButton;
+    'kyn-ai-launch-btn': AILaunchButton;
   }
 }


### PR DESCRIPTION
quick change to rename `kyn-ai-assist` to `kyn-ai-launch-btn` to remain consistent with naming throughout the component