### PR TITLE
feat(inline-confirm): add reusable component inline-confirm

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1691,69 +1691,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/global/uiShell/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "UiShell",
-          "declaration": {
-            "name": "UiShell",
-            "module": "./uiShell"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/global/uiShell/uiShell.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "Container to help with positioning and padding of the global elements such as: adds padding for the fixed Header and Local Nav, adds main content gutters, and makes Footer sticky. This takes the onus off of the consuming app to configure these values.",
-          "name": "UiShell",
-          "slots": [
-            {
-              "description": "Slot for global elements.",
-              "name": "unnamed"
-            }
-          ],
-          "members": [
-            {
-              "kind": "method",
-              "name": "handleSlotChange",
-              "privacy": "private"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "kyn-ui-shell",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "UiShell",
-          "declaration": {
-            "name": "UiShell",
-            "module": "src/components/global/uiShell/uiShell.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "kyn-ui-shell",
-          "declaration": {
-            "name": "UiShell",
-            "module": "src/components/global/uiShell/uiShell.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/components/global/localNav/index.ts",
       "declarations": [],
       "exports": [
@@ -2200,6 +2137,69 @@
           "declaration": {
             "name": "LocalNavLink",
             "module": "src/components/global/localNav/localNavLink.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/global/uiShell/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "UiShell",
+          "declaration": {
+            "name": "UiShell",
+            "module": "./uiShell"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/global/uiShell/uiShell.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Container to help with positioning and padding of the global elements such as: adds padding for the fixed Header and Local Nav, adds main content gutters, and makes Footer sticky. This takes the onus off of the consuming app to configure these values.",
+          "name": "UiShell",
+          "slots": [
+            {
+              "description": "Slot for global elements.",
+              "name": "unnamed"
+            }
+          ],
+          "members": [
+            {
+              "kind": "method",
+              "name": "handleSlotChange",
+              "privacy": "private"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kyn-ui-shell",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "UiShell",
+          "declaration": {
+            "name": "UiShell",
+            "module": "src/components/global/uiShell/uiShell.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kyn-ui-shell",
+          "declaration": {
+            "name": "UiShell",
+            "module": "src/components/global/uiShell/uiShell.ts"
           }
         }
       ]
@@ -2697,6 +2697,63 @@
           "declaration": {
             "name": "Avatar",
             "module": "./avatar"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/reusable/breadcrumbs/breadcrumbs.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Breadcrumbs Component.",
+          "name": "Breadcrumbs",
+          "slots": [
+            {
+              "description": "Slot for inserting links.",
+              "name": "unnamed"
+            }
+          ],
+          "members": [],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kyn-breadcrumbs",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Breadcrumbs",
+          "declaration": {
+            "name": "Breadcrumbs",
+            "module": "src/components/reusable/breadcrumbs/breadcrumbs.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kyn-breadcrumbs",
+          "declaration": {
+            "name": "Breadcrumbs",
+            "module": "src/components/reusable/breadcrumbs/breadcrumbs.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/reusable/breadcrumbs/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Breadcrumbs",
+          "declaration": {
+            "name": "Breadcrumbs",
+            "module": "./breadcrumbs"
           }
         }
       ]
@@ -3504,63 +3561,6 @@
           "declaration": {
             "name": "Button",
             "module": "./button"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/reusable/breadcrumbs/breadcrumbs.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "Breadcrumbs Component.",
-          "name": "Breadcrumbs",
-          "slots": [
-            {
-              "description": "Slot for inserting links.",
-              "name": "unnamed"
-            }
-          ],
-          "members": [],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "kyn-breadcrumbs",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "Breadcrumbs",
-          "declaration": {
-            "name": "Breadcrumbs",
-            "module": "src/components/reusable/breadcrumbs/breadcrumbs.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "kyn-breadcrumbs",
-          "declaration": {
-            "name": "Breadcrumbs",
-            "module": "src/components/reusable/breadcrumbs/breadcrumbs.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/reusable/breadcrumbs/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "Breadcrumbs",
-          "declaration": {
-            "name": "Breadcrumbs",
-            "module": "./breadcrumbs"
           }
         }
       ]
@@ -7110,6 +7110,177 @@
           "declaration": {
             "name": "InlineCodeView",
             "module": "src/components/reusable/inlineCodeView/inlineCodeView.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/reusable/inlineConfirm/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "InlineConfirm",
+          "declaration": {
+            "name": "InlineConfirm",
+            "module": "./inlineConfirm"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/reusable/inlineConfirm/inlineConfirm.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "InlineConfirm component.",
+          "name": "InlineConfirm",
+          "slots": [
+            {
+              "description": "Slot for anchor button icon.",
+              "name": "unnamed"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "destructive",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Determines if the action is destructive.",
+              "attribute": "destructive"
+            },
+            {
+              "kind": "field",
+              "name": "anchorText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Anchor button text.",
+              "attribute": "anchorText"
+            },
+            {
+              "kind": "field",
+              "name": "confirmText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Confirm'",
+              "description": "Confirm button text.",
+              "attribute": "confirmText"
+            },
+            {
+              "kind": "field",
+              "name": "cancelText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Cancel'",
+              "description": "Cancel button text.",
+              "attribute": "cancelText"
+            },
+            {
+              "kind": "field",
+              "name": "openRight",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Open to the right.",
+              "attribute": "openRight"
+            },
+            {
+              "kind": "method",
+              "name": "_handleToggle",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "_handleConfirm",
+              "privacy": "private"
+            }
+          ],
+          "events": [
+            {
+              "description": "Dispatched when the confirm button is clicked.",
+              "name": "on-confirm"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "destructive",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Determines if the action is destructive.",
+              "fieldName": "destructive"
+            },
+            {
+              "name": "anchorText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Anchor button text.",
+              "fieldName": "anchorText"
+            },
+            {
+              "name": "confirmText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Confirm'",
+              "description": "Confirm button text.",
+              "fieldName": "confirmText"
+            },
+            {
+              "name": "cancelText",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Cancel'",
+              "description": "Cancel button text.",
+              "fieldName": "cancelText"
+            },
+            {
+              "name": "openRight",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Open to the right.",
+              "fieldName": "openRight"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit-element"
+          },
+          "tagName": "kyn-inline-confirm",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "InlineConfirm",
+          "declaration": {
+            "name": "InlineConfirm",
+            "module": "src/components/reusable/inlineConfirm/inlineConfirm.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kyn-inline-confirm",
+          "declaration": {
+            "name": "InlineConfirm",
+            "module": "src/components/reusable/inlineConfirm/inlineConfirm.ts"
           }
         }
       ]
@@ -13013,7 +13184,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-td` Web Component.\r\n\r\nRepresents a table cell (data cell) within Shidoka's design system tables.\r\nAllows customization of alignment and can reflect the sort direction when\r\nused within sortable columns.",
+          "description": "`kyn-td` Web Component.\n\nRepresents a table cell (data cell) within Shidoka's design system tables.\nAllows customization of alignment and can reflect the sort direction when\nused within sortable columns.",
           "name": "TableCell",
           "slots": [
             {
@@ -13049,7 +13220,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a fixed width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a fixed width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "width",
               "reflects": true
             },
@@ -13060,7 +13231,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a maximum width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a maximum width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "maxWidth",
               "reflects": true
             },
@@ -13071,7 +13242,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a minimum width for the cell;\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a minimum width for the cell;\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "minWidth",
               "reflects": true
             },
@@ -13135,7 +13306,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a fixed width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a fixed width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "width"
             },
             {
@@ -13144,7 +13315,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a maximum width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a maximum width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "maxWidth"
             },
             {
@@ -13153,7 +13324,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a minimum width for the cell;\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a minimum width for the cell;\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "minWidth"
             },
             {
@@ -14094,7 +14265,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "`kyn-th` Web Component.\r\n\r\nRepresents a custom table header cell (`<th>`) for Shidoka's design system tables.\r\nProvides sorting functionality when enabled and allows alignment customization.",
+          "description": "`kyn-th` Web Component.\n\nRepresents a custom table header cell (`<th>`) for Shidoka's design system tables.\nProvides sorting functionality when enabled and allows alignment customization.",
           "name": "TableHeader",
           "slots": [
             {
@@ -14134,7 +14305,7 @@
               "type": {
                 "text": "TABLE_CELL_ALIGN"
               },
-              "description": "Specifies the alignment of the content within the table header.\r\nOptions: 'left', 'center', 'right'",
+              "description": "Specifies the alignment of the content within the table header.\nOptions: 'left', 'center', 'right'",
               "attribute": "align",
               "reflects": true
             },
@@ -14145,7 +14316,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Specifies if the column is sortable.\r\nIf set to true, an arrow icon will be displayed unpon hover,\r\nallowing the user to toggle sort directions.",
+              "description": "Specifies if the column is sortable.\nIf set to true, an arrow icon will be displayed unpon hover,\nallowing the user to toggle sort directions.",
               "attribute": "sortable",
               "reflects": true
             },
@@ -14166,7 +14337,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The textual content associated with this component.\r\nRepresents the primary content or label that will be displayed.",
+              "description": "The textual content associated with this component.\nRepresents the primary content or label that will be displayed.",
               "attribute": "headerLabel"
             },
             {
@@ -14176,7 +14347,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The unique identifier representing this column header.\r\nUsed to distinguish between different sortable columns and\r\nto ensure that only one column is sorted at a time.",
+              "description": "The unique identifier representing this column header.\nUsed to distinguish between different sortable columns and\nto ensure that only one column is sorted at a time.",
               "attribute": "sortKey"
             },
             {
@@ -14186,7 +14357,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Determines whether the content should be hidden from visual view but remain accessible\r\nto screen readers for accessibility purposes. When set to `true`, the content\r\nwill not be visibly shown, but its content can still be read by screen readers.\r\nThis is especially useful for providing additional context or information to\r\nassistive technologies without cluttering the visual UI.",
+              "description": "Determines whether the content should be hidden from visual view but remain accessible\nto screen readers for accessibility purposes. When set to `true`, the content\nwill not be visibly shown, but its content can still be read by screen readers.\nThis is especially useful for providing additional context or information to\nassistive technologies without cluttering the visual UI.",
               "attribute": "visiblyHidden"
             },
             {
@@ -14196,7 +14367,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a fixed width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a fixed width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "width",
               "reflects": true
             },
@@ -14207,7 +14378,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a maximum width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a maximum width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "maxWidth",
               "reflects": true
             },
@@ -14218,20 +14389,20 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a minimum width for the cell;\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a minimum width for the cell;\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "attribute": "minWidth",
               "reflects": true
             },
             {
               "kind": "method",
               "name": "resetSort",
-              "description": "Resets the sorting direction of the component to its default state.\r\nUseful for initializing or clearing any applied sorting on the element."
+              "description": "Resets the sorting direction of the component to its default state.\nUseful for initializing or clearing any applied sorting on the element."
             },
             {
               "kind": "method",
               "name": "toggleSortDirection",
               "privacy": "private",
-              "description": "Toggles the sort direction between ascending, descending, and default states.\r\nIt also dispatches an event to notify parent components of the sorting change."
+              "description": "Toggles the sort direction between ascending, descending, and default states.\nIt also dispatches an event to notify parent components of the sorting change."
             },
             {
               "kind": "method",
@@ -14262,7 +14433,7 @@
               "type": {
                 "text": "TABLE_CELL_ALIGN"
               },
-              "description": "Specifies the alignment of the content within the table header.\r\nOptions: 'left', 'center', 'right'",
+              "description": "Specifies the alignment of the content within the table header.\nOptions: 'left', 'center', 'right'",
               "fieldName": "align"
             },
             {
@@ -14271,7 +14442,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Specifies if the column is sortable.\r\nIf set to true, an arrow icon will be displayed unpon hover,\r\nallowing the user to toggle sort directions.",
+              "description": "Specifies if the column is sortable.\nIf set to true, an arrow icon will be displayed unpon hover,\nallowing the user to toggle sort directions.",
               "fieldName": "sortable"
             },
             {
@@ -14288,7 +14459,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The textual content associated with this component.\r\nRepresents the primary content or label that will be displayed.",
+              "description": "The textual content associated with this component.\nRepresents the primary content or label that will be displayed.",
               "fieldName": "headerLabel"
             },
             {
@@ -14297,7 +14468,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The unique identifier representing this column header.\r\nUsed to distinguish between different sortable columns and\r\nto ensure that only one column is sorted at a time.",
+              "description": "The unique identifier representing this column header.\nUsed to distinguish between different sortable columns and\nto ensure that only one column is sorted at a time.",
               "fieldName": "sortKey"
             },
             {
@@ -14306,7 +14477,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Determines whether the content should be hidden from visual view but remain accessible\r\nto screen readers for accessibility purposes. When set to `true`, the content\r\nwill not be visibly shown, but its content can still be read by screen readers.\r\nThis is especially useful for providing additional context or information to\r\nassistive technologies without cluttering the visual UI.",
+              "description": "Determines whether the content should be hidden from visual view but remain accessible\nto screen readers for accessibility purposes. When set to `true`, the content\nwill not be visibly shown, but its content can still be read by screen readers.\nThis is especially useful for providing additional context or information to\nassistive technologies without cluttering the visual UI.",
               "fieldName": "visiblyHidden"
             },
             {
@@ -14315,7 +14486,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a fixed width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a fixed width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "width"
             },
             {
@@ -14324,7 +14495,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a maximum width for the cell.\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a maximum width for the cell.\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "maxWidth"
             },
             {
@@ -14333,7 +14504,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "Sets a minimum width for the cell;\r\nAccepts standard CSS width values (e.g., '150px', '50%').",
+              "description": "Sets a minimum width for the cell;\nAccepts standard CSS width values (e.g., '150px', '50%').",
               "fieldName": "minWidth"
             }
           ],

--- a/src/components/reusable/inlineConfirm/index.ts
+++ b/src/components/reusable/inlineConfirm/index.ts
@@ -1,0 +1,1 @@
+export { InlineConfirm } from './inlineConfirm';

--- a/src/components/reusable/inlineConfirm/inlineConfirm.scss
+++ b/src/components/reusable/inlineConfirm/inlineConfirm.scss
@@ -1,0 +1,43 @@
+@use '../../../common/scss/global.scss';
+
+:host {
+  display: inline-block;
+}
+
+.inline-confirm {
+  position: relative;
+}
+
+.confirmation {
+  display: flex;
+  gap: 16px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  transition: transform 250ms ease-out, opacity 250ms ease-out,
+    visibility 250ms ease-out;
+  transform: translateX(100%);
+  visibility: hidden;
+  opacity: 0;
+
+  .open-right & {
+    right: auto;
+    left: 0;
+    transform: translateX(-100%);
+    flex-direction: row-reverse;
+  }
+
+  .open & {
+    transform: translateX(0);
+    visibility: visible;
+    opacity: 1;
+  }
+}
+
+.anchor {
+  transition: opacity 250ms ease-out;
+
+  .open & {
+    opacity: 0;
+  }
+}

--- a/src/components/reusable/inlineConfirm/inlineConfirm.stories.js
+++ b/src/components/reusable/inlineConfirm/inlineConfirm.stories.js
@@ -1,0 +1,40 @@
+import { html } from 'lit-html';
+import { action } from '@storybook/addon-actions';
+import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js';
+import './index';
+import '../button'; // Import the button component
+
+import deleteIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/24/delete.svg';
+
+export default {
+  title: 'Components/Inline Confirm',
+  component: 'kyn-inline-confirm',
+  decorators: [
+    (story) =>
+      html`
+        <div style="display: flex; justify-content: center;">${story()}</div>
+      `,
+  ],
+};
+
+const Template = (args) => html`
+  <kyn-inline-confirm
+    .destructive=${args.destructive}
+    .anchorText=${args.anchorText}
+    .confirmText=${args.confirmText}
+    .cancelText=${args.cancelText}
+    .openRight=${args.openRight}
+    @on-confirm=${(e) => action('on-confirm')()}
+  >
+    ${unsafeSVG(deleteIcon)}
+  </kyn-inline-confirm>
+`;
+
+export const Default = Template.bind({});
+Default.args = {
+  destructive: true,
+  anchorText: 'Delete',
+  confirmText: 'Confirm',
+  cancelText: 'Cancel',
+  openRight: false,
+};

--- a/src/components/reusable/inlineConfirm/inlineConfirm.ts
+++ b/src/components/reusable/inlineConfirm/inlineConfirm.ts
@@ -1,0 +1,109 @@
+import { LitElement, html, property, customElement, state } from 'lit-element';
+import { classMap } from 'lit/directives/class-map.js';
+import styles from './inlineConfirm.scss';
+import '../button';
+
+/**
+ * InlineConfirm component.
+ * @slot unnamed - Slot for anchor button icon.
+ * @fires on-confirm - Dispatched when the confirm button is clicked.
+ */
+@customElement('kyn-inline-confirm')
+export class InlineConfirm extends LitElement {
+  static override styles = styles;
+
+  /**
+   * Determines if the action is destructive.
+   * @type {boolean}
+   */
+  @property({ type: Boolean })
+  destructive = false;
+
+  /**
+   * Anchor button text.
+   * @type {string}
+   */
+  @property({ type: String })
+  anchorText = '';
+
+  /**
+   * Confirm button text.
+   * @type {string}
+   */
+  @property({ type: String })
+  confirmText = 'Confirm';
+
+  /**
+   * Cancel button text.
+   * @type {string}
+   */
+  @property({ type: String })
+  cancelText = 'Cancel';
+
+  /**
+   * Open to the right.
+   * @type {boolean}
+   */
+  @property({ type: Boolean })
+  openRight = false;
+
+  /**
+   * Confirmation open state.
+   * @internal
+   */
+  @state()
+  private _isOpen = false;
+
+  private _handleToggle() {
+    this._isOpen = !this._isOpen;
+  }
+
+  private _handleConfirm() {
+    this._handleToggle();
+
+    const event = new CustomEvent('on-confirm');
+    this.dispatchEvent(event);
+  }
+
+  override render() {
+    const Classes = {
+      'inline-confirm': true,
+      open: this._isOpen,
+      'open-right': this.openRight,
+    };
+
+    return html`
+      <div class="${classMap(Classes)}">
+        <kyn-button
+          class="anchor"
+          kind="ghost"
+          size="small"
+          description=${this.anchorText}
+          @on-click=${this._handleToggle}
+        >
+          <slot slot="icon"></slot>
+        </kyn-button>
+
+        <div class="confirmation">
+          <kyn-button
+            kind=${this.destructive ? 'outline-destructive' : 'outline'}
+            size="small"
+            @on-click=${this._handleConfirm}
+          >
+            ${this.confirmText}
+          </kyn-button>
+
+          <kyn-button kind="ghost" size="small" @on-click=${this._handleToggle}>
+            ${this.cancelText}
+          </kyn-button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'kyn-inline-confirm': InlineConfirm;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,3 +110,4 @@ export {
   SplitButtonOption,
 } from './components/reusable/splitButton';
 export { FloatingContainer } from './components/reusable/floatingContainer';
+export { InlineConfirm } from './components/reusable/inlineConfirm';


### PR DESCRIPTION
## Summary

Add a reusable inline confirmation component in support of the AI Info & Chat History patterns.

## ADO Story or GitHub Issue Link

fixes AB#2136681

## Figma Link

https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=29700-3508&m=dev