### PR TITLE
fix(datepicker): reinitialize on _handleClear, more robust locales

### DIFF
--- a/src/common/helpers/flatpickr.ts
+++ b/src/common/helpers/flatpickr.ts
@@ -522,30 +522,30 @@ export function setCalendarAttributes(
 
 export async function loadLocale(locale: string): Promise<Partial<Locale>> {
   if (locale === 'en') return English;
+
   if (!isSupportedLocale(locale)) {
-    console.warn(`Unsupported locale: ${locale}. Falling back to English.`);
+    console.warn(`Unsupported locale "${locale}". Falling back to English.`);
     return English;
   }
 
   try {
     const module = await import(`flatpickr/dist/l10n/${locale}.js`);
     const localeConfig =
-      module[locale] || module.default[locale] || module.default;
+      module[locale] ?? module.default?.[locale] ?? module.default;
+
     if (!localeConfig) {
       console.warn(
-        `Locale configuration not found for ${locale}. Falling back to English.`
+        `Locale configuration not found for "${locale}". Falling back to English.`
       );
       return English;
     }
+
     return localeConfig;
   } catch (error) {
     console.error(
-      `Failed to load locale ${locale}. Falling back to English.`,
+      `Failed to load locale "${locale}". Falling back to English.`,
       error
     );
-    if (error instanceof Error) {
-      console.error('Error details:', error.message);
-    }
     return English;
   }
 }

--- a/src/components/reusable/datePicker/datepicker.ts
+++ b/src/components/reusable/datePicker/datepicker.ts
@@ -56,7 +56,7 @@ export class DatePicker extends FormMixin(LitElement) {
 
   /* Sets desired locale and, if supported, dynamically loads language lib */
   @property({ type: String })
-  locale: SupportedLocale = 'en';
+  locale: SupportedLocale | string = 'en';
 
   /** Sets flatpickr value to define how the date will be displayed in the input box (ex: `Y-m-d H:i`). */
   @property({ type: String })

--- a/src/components/reusable/datePicker/datepicker.ts
+++ b/src/components/reusable/datePicker/datepicker.ts
@@ -37,6 +37,7 @@ const _defaultTextStrings = {
   requiredText: 'Required',
   clearAll: 'Clear',
   pleaseSelectDate: 'Please select a date',
+  noDateSelected: 'No date selected',
   pleaseSelectValidDate: 'Please select a valid date',
 };
 
@@ -504,6 +505,10 @@ export class DatePicker extends FormMixin(LitElement) {
       this.flatpickrInstance.clear();
       if (this._inputEl) {
         this._inputEl.value = '';
+        this._inputEl.setAttribute(
+          'aria-label',
+          this._textStrings.noDateSelected
+        );
       }
 
       emitValue(this, 'on-change', {
@@ -514,6 +519,7 @@ export class DatePicker extends FormMixin(LitElement) {
 
       this._validate(true, false);
       await this.updateComplete;
+      await this.initializeFlatpickr();
       this.requestUpdate();
     } catch (error) {
       console.error('Error clearing datepicker:', error);

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -59,7 +59,7 @@ export class DateRangePicker extends FormMixin(LitElement) {
 
   /** Sets and dynamically imports specific l10n calendar localization. */
   @property({ type: String })
-  locale: SupportedLocale = 'en';
+  locale: SupportedLocale | string = 'en';
 
   /** Sets flatpickr value to define how the date will be displayed in the input box (ex: `Y-m-d H:i`). */
   @property({ type: String })

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -501,20 +501,22 @@ export class DateRangePicker extends FormMixin(LitElement) {
   }
 
   private async _handleClear(event: Event) {
+    this._isClearing = true;
     event.preventDefault();
     event.stopPropagation();
-
-    this._isClearing = true;
-
     try {
       this.value = [null, null];
       this.defaultDate = null;
 
       if (this.flatpickrInstance) {
         this.flatpickrInstance.clear();
-        if (this._inputEl) {
-          this._inputEl.value = '';
-        }
+      }
+      if (this._inputEl) {
+        this._inputEl.value = '';
+        this._inputEl.setAttribute(
+          'aria-label',
+          this._textStrings.noDateSelected
+        );
       }
 
       emitValue(this, 'on-change', {
@@ -525,6 +527,8 @@ export class DateRangePicker extends FormMixin(LitElement) {
 
       this._validate(true, false);
       await this.updateComplete;
+
+      await this.initializeFlatpickr();
       this.requestUpdate();
     } finally {
       this._isClearing = false;

--- a/src/components/reusable/timepicker/timepicker.ts
+++ b/src/components/reusable/timepicker/timepicker.ts
@@ -57,7 +57,7 @@ export class TimePicker extends FormMixin(LitElement) {
 
   /** Sets desired locale and, if supported, dynamically loads language lib */
   @property({ type: String })
-  locale: SupportedLocale = 'en';
+  locale: SupportedLocale | string = 'en';
 
   /** Sets date/time value. */
   @property({ type: Object })

--- a/src/components/reusable/timepicker/timepicker.ts
+++ b/src/components/reusable/timepicker/timepicker.ts
@@ -38,6 +38,7 @@ const _defaultTextStrings = {
   requiredText: 'Required',
   clearAll: 'Clear',
   pleaseSelectDate: 'Please select a date',
+  noTimeSelected: 'No time selected',
   pleaseSelectValidDate: 'Please select a valid date',
 };
 
@@ -410,6 +411,10 @@ export class TimePicker extends FormMixin(LitElement) {
         this.flatpickrInstance.clear();
         if (this._inputEl) {
           this._inputEl.value = '';
+          this._inputEl.setAttribute(
+            'aria-label',
+            this._textStrings.noTimeSelected
+          );
         }
       }
       emitValue(this, 'on-change', {
@@ -418,6 +423,7 @@ export class TimePicker extends FormMixin(LitElement) {
       });
       this._validate(true, false);
       await this.updateComplete;
+      await this.initializeFlatpickr();
       this.requestUpdate();
     } finally {
       this._isClearing = false;


### PR DESCRIPTION
## Summary

1. From dev implementing date-range picker in his application:
"having a problem when I clear the dates from the input but then cancel the change. When I reopen the modal, I see the dates placeholder, not the dates, although there's a 'clear' icon there, so it appears it knows it has some value??"

to ensure that clear takes effect, we are now:
- resetting the component's internal state (value, defaultDate) to a cleared state
- calling Flatpickr's clear method and updating the input's value and ARIA label
- emitting the on-change event
- reinitializing Flatpickr's instance to ensure any dependent UI/state remains in sync after clear

2. dynamic language string wouldn't be accepted for `locale` prop, made more robust. handles errors with graceful fallback to 'en,' when needed

