### PR TITLE
fix: use focus-visible instead of focus

### DIFF
--- a/src/common/scss/form-input.scss
+++ b/src/common/scss/form-input.scss
@@ -74,7 +74,7 @@ textarea {
     border-color: var(--kd-color-border-ui-hover);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 

--- a/src/common/scss/shidoka-flatpickr-theme.scss
+++ b/src/common/scss/shidoka-flatpickr-theme.scss
@@ -292,7 +292,7 @@ $calendar-box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.08),
   top: 100%;
 }
 
-.flatpickr-calendar:focus {
+.flatpickr-calendar:focus-visible {
   outline: 0;
 }
 
@@ -346,7 +346,7 @@ $calendar-box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.08),
   color: $icon-fill;
   fill: $icon-fill;
 
-  &:focus {
+  &:focus-visible {
     outline: 2px solid var(--kd-color-date-and-time-picker-border-focus);
     outline-offset: 2px;
   }
@@ -531,8 +531,8 @@ $calendar-box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.08),
   transform: translate3d(0px, 0px, 0px);
   color: $current-month-year;
 
-  .flatpickr-monthDropdown-months:focus,
-  input.cur-year:focus {
+  .flatpickr-monthDropdown-months:focus-visible,
+  input.cur-year:focus-visible {
     outline: 2px solid var(--kd-color-date-and-time-picker-border-focus);
     outline-offset: 2px;
   }
@@ -583,7 +583,7 @@ $calendar-box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.08),
   appearance: textfield;
 }
 
-.flatpickr-current-month input.cur-year:focus {
+.flatpickr-current-month input.cur-year:focus-visible {
   outline: 0;
 }
 
@@ -619,7 +619,7 @@ $calendar-box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.08),
   width: auto;
 }
 
-.flatpickr-current-month .flatpickr-monthDropdown-months:focus,
+.flatpickr-current-month .flatpickr-monthDropdown-months:focus-visible,
 .flatpickr-current-month .flatpickr-monthDropdown-months:active {
   outline: none;
 }
@@ -699,7 +699,7 @@ span.flatpickr-weekday {
   width: 316px;
 }
 
-.flatpickr-days:focus {
+.flatpickr-days:focus-visible {
   outline: 0;
 }
 
@@ -754,7 +754,7 @@ span.flatpickr-weekday {
   justify-content: center;
   text-align: center;
 
-  &:focus {
+  &:focus-visible {
     outline: 2px solid var(--kd-color-date-and-time-picker-border-focus);
     outline-offset: 2px;
   }
@@ -793,9 +793,9 @@ span.flatpickr-weekday {
 .flatpickr-day:hover,
 .flatpickr-day.prevMonthDay:hover,
 .flatpickr-day.nextMonthDay:hover,
-.flatpickr-day:focus,
-.flatpickr-day.prevMonthDay:focus,
-.flatpickr-day.nextMonthDay:focus {
+.flatpickr-day:focus-visible,
+.flatpickr-day.prevMonthDay:focus-visible,
+.flatpickr-day.nextMonthDay:focus-visible {
   background: var(--kd-color-date-and-time-picker-background-hover);
   color: var(--kd-color-date-and-time-picker-text-default);
   border-color: transparent;
@@ -806,7 +806,7 @@ span.flatpickr-weekday {
 }
 
 .flatpickr-day.today:hover,
-.flatpickr-day.today:focus {
+.flatpickr-day.today:focus-visible {
   border-color: transparent;
   background: var(--kd-color-date-and-time-picker-background-hover);
   color: var(--kd-color-date-and-time-picker-text-default);
@@ -817,9 +817,9 @@ span.flatpickr-weekday {
 .flatpickr-day.startRange,
 .flatpickr-day.startRange.inRange,
 .flatpickr-day.endRange.inRange,
-.flatpickr-day.selected:focus,
-.flatpickr-day.startRange:focus,
-.flatpickr-day.endRange:focus,
+.flatpickr-day.selected:focus-visible,
+.flatpickr-day.startRange:focus-visible,
+.flatpickr-day.endRange:focus-visible,
 .flatpickr-day.selected:hover,
 .flatpickr-day.startRange:hover,
 .flatpickr-day.endRange:hover,
@@ -1023,7 +1023,7 @@ span.flatpickr-weekday {
     background-color: transparent;
   }
 
-  &:focus {
+  &:focus-visible {
     outline: 2px solid var(--kd-color-date-and-time-picker-border-focus);
     outline-offset: 2px;
   }
@@ -1043,7 +1043,7 @@ span.flatpickr-weekday {
   font-weight: 500;
 }
 
-.flatpickr-time input:focus {
+.flatpickr-time input:focus-visible {
   outline: 0;
   border: none;
 }
@@ -1075,8 +1075,8 @@ span.flatpickr-weekday {
 
 .flatpickr-time input:hover,
 .flatpickr-time .flatpickr-am-pm:hover,
-.flatpickr-time input:focus,
-.flatpickr-time .flatpickr-am-pm:focus {
+.flatpickr-time input:focus-visible,
+.flatpickr-time .flatpickr-am-pm:focus-visible {
   background: var(--kd-color-date-and-time-picker-background-container-2);
 }
 

--- a/src/common/scss/utility/swiper-shidoka.scss
+++ b/src/common/scss/utility/swiper-shidoka.scss
@@ -103,7 +103,7 @@
         background-color: var(--kd-color-background-ui-hollow-hover);
       }
 
-      &:focus {
+      &:focus-visible {
         color: var(--kd-color-text-level-primary);
         outline-color: var(--kd-color-border-variants-focus);
       }
@@ -184,7 +184,7 @@
     display: flex;
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-ui-hover);
   }
 

--- a/src/components/ai/aiLaunchButton/aiLaunchButton.scss
+++ b/src/components/ai/aiLaunchButton/aiLaunchButton.scss
@@ -24,7 +24,7 @@
     border-color: var(--kd-color-border-variants-ai);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-button-primary-state-focused);
     outline-offset: -2px;
   }

--- a/src/components/global/header/header-interactive.scss
+++ b/src/components/global/header/header-interactive.scss
@@ -12,7 +12,7 @@
   outline: 2px solid transparent;
   outline-offset: -2px;
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 
@@ -173,7 +173,7 @@
     color: var(--kd-color-text-button-dark-primary);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 

--- a/src/components/global/header/headerLink.scss
+++ b/src/components/global/header/headerLink.scss
@@ -26,7 +26,7 @@
     padding-right: 16px;
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
     background: var(--kd-color-background-menu-state-focused);
     color: var(--kd-color-text-level-primary);

--- a/src/components/global/header/headerPanelLink.scss
+++ b/src/components/global/header/headerPanelLink.scss
@@ -25,7 +25,7 @@ a {
     color: var(--kd-color-text-inversed);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-focus);
   }
 

--- a/src/components/global/localNav/localNav.scss
+++ b/src/components/global/localNav/localNav.scss
@@ -146,7 +146,7 @@ slot[name='search'] {
   width: 100%;
   height: 48px;
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 

--- a/src/components/global/localNav/localNavLink.scss
+++ b/src/components/global/localNav/localNavLink.scss
@@ -51,7 +51,7 @@ a {
     color: var(--kd-color-text-button-dark-primary);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 
@@ -211,7 +211,7 @@ a {
     color: var(--kd-color-text-button-dark-primary);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 

--- a/src/components/reusable/accordion/accordion.scss
+++ b/src/components/reusable/accordion/accordion.scss
@@ -56,7 +56,7 @@
         text-decoration: underline;
       }
 
-      &:focus {
+      &:focus-visible {
         outline-color: var(--kd-color-border-variants-focus);
       }
     }

--- a/src/components/reusable/accordion/accordionItem.scss
+++ b/src/components/reusable/accordion/accordionItem.scss
@@ -82,7 +82,7 @@
     background-color: var(--kd-color-background-accent-subtle);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 

--- a/src/components/reusable/button/button.scss
+++ b/src/components/reusable/button/button.scss
@@ -140,7 +140,7 @@
       background-color: var(--kd-color-background-button-primary-state-hover);
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-button-primary-state-focused);
     }
 
@@ -162,7 +162,7 @@
       background-color: var(--kd-color-background-button-primary-ai-hover);
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-button-ai-state-focused);
     }
 
@@ -186,7 +186,7 @@
       );
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-button-primary-destructive-focused);
     }
 
@@ -208,7 +208,7 @@
       background-color: var(--kd-color-background-button-secondary-state-hover);
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-button-secondary-state-focused);
     }
 
@@ -230,7 +230,7 @@
       background-color: var(--kd-color-background-button-secondary-ai-hover);
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-button-ai-state-focused);
     }
 
@@ -259,7 +259,7 @@
       );
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-button-primary-destructive-default);
     }
 
@@ -287,7 +287,7 @@
       color: var(--kd-color-text-button-dark-primary);
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-button-tertiary-state-focused);
     }
 
@@ -309,7 +309,7 @@
       background-color: var(--kd-color-background-button-web-hover);
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-variants-focus);
     }
 
@@ -347,7 +347,7 @@
       border-color: var(--kd-color-border-button-primary-state-hover);
     }
 
-    &:focus {
+    &:focus-visible {
       border-color: var(--kd-color-border-button-primary-state-focused);
       outline-color: var(--kd-color-border-button-primary-state-focused);
     }
@@ -369,7 +369,7 @@
       color: var(--kd-color-text-level-light);
     }
 
-    &:focus {
+    &:focus-visible {
       border-color: var(--kd-color-border-button-ai-state-focused);
       outline-color: var(--kd-color-border-button-ai-state-focused);
     }
@@ -393,7 +393,7 @@
       color: var(--kd-color-text-level-primary);
     }
 
-    &:focus {
+    &:focus-visible {
       border-color: var(--kd-color-border-button-primary-destructive-focused);
       outline-color: var(--kd-color-border-button-primary-destructive-focused);
     }
@@ -414,7 +414,7 @@
       background-color: var(--kd-color-background-button-ghost-state-hover);
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-button-tertiary-state-focused);
     }
 

--- a/src/components/reusable/card/card.scss
+++ b/src/components/reusable/card/card.scss
@@ -42,7 +42,7 @@
       @include elevation.shadow(2);
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-ui-hover);
       @include elevation.shadow(2);
     }
@@ -54,7 +54,7 @@
         outline-color: var(--kd-color-border-button-ai-state-hover);
         @include elevation.shadow(2, true);
       }
-      &:focus {
+      &:focus-visible {
         outline-color: var(--kd-color-border-button-ai-state-hover);
         @include elevation.shadow(2, true);
       }
@@ -66,7 +66,7 @@
         outline-color: var(--kd-color-border-button-ai-state-hover);
         @include elevation.shadow(2, true);
       }
-      &:focus {
+      &:focus-visible {
         outline-color: var(--kd-color-border-button-ai-state-hover);
         @include elevation.shadow(2, true);
       }

--- a/src/components/reusable/checkbox/checkbox.scss
+++ b/src/components/reusable/checkbox/checkbox.scss
@@ -70,7 +70,7 @@ input {
       border-color: var(--kd-color-border-ui-hover);
     }
 
-    &:focus {
+    &:focus-visible {
       border-color: var(--kd-color-border-forms-default);
       outline-color: var(--kd-color-border-variants-focus);
       background: var(--kd-color-background-ui-hollow-default);
@@ -109,7 +109,7 @@ input {
       }
     }
 
-    &:focus {
+    &:focus-visible {
       border-color: transparent;
       outline-color: var(--kd-color-border-variants-focus);
     }
@@ -160,9 +160,11 @@ input[type='checkbox']:indeterminate {
       transform: scale(1);
       background: var(--kd-color-background-ui-hollow-default);
       mask: linear-gradient(transparent 3px, #000 3px 5px, transparent 5px);
-      -webkit-mask: linear-gradient(transparent 3px,
-          #000 3px 5px,
-          transparent 5px);
+      -webkit-mask: linear-gradient(
+        transparent 3px,
+        #000 3px 5px,
+        transparent 5px
+      );
     }
 
     &:hover {
@@ -197,9 +199,11 @@ input[type='checkbox']:indeterminate:disabled {
     transform: scale(1);
     background: var(--kd-color-background-ui-hollow-default);
     mask: linear-gradient(transparent 3px, #000 3px 5px, transparent 5px);
-    -webkit-mask: linear-gradient(transparent 3px,
-        #000 3px 5px,
-        transparent 5px);
+    -webkit-mask: linear-gradient(
+      transparent 3px,
+      #000 3px 5px,
+      transparent 5px
+    );
   }
 }
 
@@ -207,7 +211,6 @@ input[type='checkbox'][invalid] {
   border-color: $invalid-checkbox-background;
 
   &:not([disabled]) {
-
     &:checked,
     &:indeterminate {
       background: $invalid-checkbox-background;
@@ -215,13 +218,21 @@ input[type='checkbox'][invalid] {
 
       &:hover {
         background: var(--kd-color-background-button-primary-destructive-hover);
-        border-color: var(--kd-color-background-button-primary-destructive-hover);
+        border-color: var(
+          --kd-color-background-button-primary-destructive-hover
+        );
       }
 
       &:active {
-        background: var(--kd-color-background-button-primary-destructive-pressed);
-        border-color: var(--kd-color-background-button-primary-destructive-pressed);
-        outline-color: var(--kd-color-background-button-primary-destructive-pressed);
+        background: var(
+          --kd-color-background-button-primary-destructive-pressed
+        );
+        border-color: var(
+          --kd-color-background-button-primary-destructive-pressed
+        );
+        outline-color: var(
+          --kd-color-background-button-primary-destructive-pressed
+        );
       }
     }
   }
@@ -243,7 +254,7 @@ input[type='checkbox'][invalid] {
     }
 
     &:active,
-    &:focus {
+    &:focus-visible {
       background-color: transparent;
       border-color: var(--kd-color-border-ui-disabled);
       outline-color: transparent;
@@ -255,7 +266,7 @@ input[type='checkbox'][invalid] {
     border-color: var(--kd-color-background-button-primary-destructive-hover);
   }
 
-  &:focus {
+  &:focus-visible {
     border-color: $invalid-checkbox-background;
     outline-color: $invalid-checkbox-background;
   }
@@ -263,7 +274,9 @@ input[type='checkbox'][invalid] {
   &:active {
     background: var(--kd-color-background-button-primary-destructive-pressed);
     border-color: var(--kd-color-background-button-primary-destructive-pressed);
-    outline-color: var(--kd-color-background-button-primary-destructive-pressed);
+    outline-color: var(
+      --kd-color-background-button-primary-destructive-pressed
+    );
   }
 }
 

--- a/src/components/reusable/checkbox/checkboxGroup.scss
+++ b/src/components/reusable/checkbox/checkboxGroup.scss
@@ -60,7 +60,7 @@ fieldset {
     color: var(--kd-color-text-pressed);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-focus);
   }
 }

--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -136,7 +136,7 @@ slot[name='icon']::slotted(*) {
     z-index: 11;
   }
 
-  [searchable] &:focus {
+  [searchable] &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 }

--- a/src/components/reusable/link/link.scss
+++ b/src/components/reusable/link/link.scss
@@ -31,7 +31,7 @@
     &:hover {
       color: var(--kd-color-text-link-level-hover);
     }
-    &:focus {
+    &:focus-visible {
       color: var(--kd-color-text-link-level-default);
       outline: 1px solid var(--kd-color-border-variants-focus);
       -webkit-transition: outline 100ms ease-in-out;
@@ -54,7 +54,7 @@
     &:hover {
       color: var(--kd-color-background-link-level-hover-light);
     }
-    &:focus {
+    &:focus-visible {
       color: var(--kd-color-background-link-level-default-light);
       outline: 1px solid var(--kd-color-border-variants-focus);
       transition: outline 100ms ease-in-out;
@@ -74,7 +74,7 @@
     &:hover {
       color: var(--kd-color-text-link-level-hover);
     }
-    &:focus {
+    &:focus-visible {
       outline: 1px solid var(--kd-color-text-level-primary);
       -webkit-transition: outline 100ms ease-in-out;
       -moz-transition: outline 100ms ease-in-out;
@@ -98,7 +98,7 @@
     pointer-events: none;
 
     &:hover,
-    &:focus,
+    &:focus-visible,
     &:active,
     &:visited {
       color: var(--kd-color-text-link-level-disabled);
@@ -151,7 +151,7 @@
       color: var(--kd-color-background-link-ai-hover);
     }
 
-    &:focus {
+    &:focus-visible {
       color: var(--kd-color-background-link-ai-focused);
       outline: 1px solid var(--kd-color-border-button-ai-state-focused);
       -webkit-transition: outline 100ms ease-in-out;

--- a/src/components/reusable/numberInput/numberInput.scss
+++ b/src/components/reusable/numberInput/numberInput.scss
@@ -23,7 +23,7 @@ input {
   height: 48px;
   padding: 0 16px;
 
-  &:focus {
+  &:focus-visible {
     outline-color: transparent;
   }
 

--- a/src/components/reusable/overflowMenu/overflowMenu.scss
+++ b/src/components/reusable/overflowMenu/overflowMenu.scss
@@ -24,7 +24,7 @@ button {
     background: var(--kd-color-background-container-default);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 

--- a/src/components/reusable/overflowMenu/overflowMenuItem.scss
+++ b/src/components/reusable/overflowMenu/overflowMenuItem.scss
@@ -28,7 +28,7 @@
     background: var(--kd-color-background-ui-hollow-hover);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 

--- a/src/components/reusable/radioButton/radioButton.scss
+++ b/src/components/reusable/radioButton/radioButton.scss
@@ -67,7 +67,7 @@ input {
       }
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-variants-focus);
     }
 
@@ -87,7 +87,7 @@ input {
     border-color: var(--kd-color-border-ui-hover);
   }
 
-  &:not([disabled]):focus {
+  &:not([disabled]):focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
     outline-offset: 2px;
 
@@ -117,7 +117,7 @@ input {
       }
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-status-error-dark);
     }
 

--- a/src/components/reusable/search/search.scss
+++ b/src/components/reusable/search/search.scss
@@ -48,7 +48,7 @@ kyn-text-input {
   z-index: -1;
 
   .focused.has-value &,
-  &:focus {
+  &:focus-visible {
     visibility: visible;
     transform: none;
     opacity: 1;

--- a/src/components/reusable/splitButton/splitButton.scss
+++ b/src/components/reusable/splitButton/splitButton.scss
@@ -131,7 +131,7 @@ span {
     }
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-background-button-primary-state-focused);
   }
 
@@ -152,7 +152,7 @@ span {
     background-color: var(--kd-color-background-button-web-pressed);
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 }
@@ -199,7 +199,7 @@ span {
     );
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(
       --kd-color-background-button-primary-destructive-focused
     );
@@ -232,7 +232,7 @@ span {
     border-color: var(--kd-color-border-button-secondary-state-pressed);
   }
 
-  &:focus {
+  &:focus-visible {
     border-width: 2px;
     border-color: var(--kd-color-border-button-secondary-state-focused);
   }
@@ -256,7 +256,7 @@ span {
     border-color: var(--kd-color-border-button-secondary-destructive-pressed);
   }
 
-  &:focus {
+  &:focus-visible {
     border-color: var(--kd-color-border-button-secondary-destructive-focused);
     outline-color: var(--kd-color-border-button-primary-destructive-default);
   }

--- a/src/components/reusable/table/story-helpers/column-setting.sample.ts
+++ b/src/components/reusable/table/story-helpers/column-setting.sample.ts
@@ -32,11 +32,11 @@ class StoryColumSetting extends LitElement {
     .unlockedRow:hover kyn-button {
       opacity: 1;
     }
-    .unlockedRow:focus kyn-button {
+    .unlockedRow:focus-visible kyn-button {
       opacity: 1;
     }
 
-    .freeze-button:focus {
+    .freeze-button:focus-visible {
       opacity: 1;
     }
     kyn-global-filter {

--- a/src/components/reusable/table/table-header.scss
+++ b/src/components/reusable/table/table-header.scss
@@ -25,7 +25,7 @@
     transition: outline-color 0.2s ease-in-out;
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       .sort-icon {
         transition: background-color 0.3s;
         color: var(--kd-color-text-tertiary);
@@ -33,7 +33,7 @@
       }
     }
 
-    &:focus {
+    &:focus-visible {
       outline-color: var(--kd-color-border-variants-focus);
     }
   }

--- a/src/components/reusable/tabs/tab.scss
+++ b/src/components/reusable/tabs/tab.scss
@@ -9,7 +9,7 @@
   transition: outline-color 150ms ease-out;
 }
 
-:host(:focus) {
+:host(:focus-visible) {
   outline-color: var(--kd-color-border-variants-focus);
 
   .tab {
@@ -17,19 +17,19 @@
   }
 }
 
-:host([data-aiconnected='true'][data-tab-style='contained']:focus) {
+:host([data-aiconnected='true'][data-tab-style='contained']:focus-visible) {
   outline-color: var(--kd-color-border-button-ai-state-hover);
   background: transparent;
   color: var(--kd-color-text-button-ai-default);
 }
 
-:host([data-aiconnected='true'][data-tab-style='line']:focus) {
+:host([data-aiconnected='true'][data-tab-style='line']:focus-visible) {
   outline-color: var(--kd-color-border-button-ai-state-focused);
   background: transparent;
   color: var(--kd-color-text-button-ai-default);
 }
 
-:host([disabled]:focus) {
+:host([disabled]:focus-visible) {
   outline-color: transparent;
 }
 

--- a/src/components/reusable/tabs/tabs.scss
+++ b/src/components/reusable/tabs/tabs.scss
@@ -77,7 +77,7 @@
     outline: 2px solid transparent;
   }
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 }

--- a/src/components/reusable/tag/tag.scss
+++ b/src/components/reusable/tag/tag.scss
@@ -49,7 +49,7 @@
       outline-offset: -3px;
     }
 
-    &:focus,
+    &:focus-visible,
     &:active {
       outline-offset: -4px;
     }
@@ -63,7 +63,7 @@
       outline-offset: -3px;
     }
 
-    &:focus,
+    &:focus-visible,
     &:active {
       outline-offset: -4px;
     }
@@ -74,7 +74,7 @@
     outline-style: solid;
   }
 
-  &:focus,
+  &:focus-visible,
   &:active {
     outline-width: 1px;
     outline-style: solid;
@@ -133,7 +133,7 @@
   &-clickable {
     cursor: pointer;
 
-    &:focus,
+    &:focus-visible,
     &:active {
       outline: 1px solid var(--kd-color-border-variants-focus);
       outline-offset: 1px;
@@ -345,7 +345,7 @@
         background-color: var(--kd-color-tags-hover-gray);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-gray);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -371,7 +371,7 @@
         background-color: var(--kd-color-tags-hover-spruce);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-spruce);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -397,7 +397,7 @@
         background-color: var(--kd-color-tags-hover-interactive);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-interactive);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -423,7 +423,7 @@
         background-color: var(--kd-color-tags-hover-blue);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-blue);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -449,7 +449,7 @@
         background-color: var(--kd-color-tags-hover-error-light);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-error-light);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -475,7 +475,7 @@
         background-color: var(--kd-color-tags-hover-warning-light);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-warning-light);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -501,7 +501,7 @@
         background-color: var(--kd-color-tags-hover-success-light);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-success-light);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -527,7 +527,7 @@
         background-color: var(--kd-color-tags-hover-cat-1);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-cat-1);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -553,7 +553,7 @@
         background-color: var(--kd-color-tags-hover-cat-2);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-cat-2);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -579,7 +579,7 @@
         background-color: var(--kd-color-tags-hover-cat-3);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-cat-3);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -605,7 +605,7 @@
         background-color: var(--kd-color-tags-hover-cat-4);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-cat-4);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -631,7 +631,7 @@
         background-color: var(--kd-color-tags-hover-cat-5);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-cat-5);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -657,7 +657,7 @@
         background-color: var(--kd-color-tags-hover-cat-6);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-cat-6);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -684,7 +684,7 @@
         background-color: var(--kd-color-tags-hover-success);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-success);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -711,7 +711,7 @@
         background-color: var(--kd-color-tags-hover-error-light);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-error-light);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -738,7 +738,7 @@
         background-color: var(--kd-color-tags-hover-warning);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-warning);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -765,7 +765,7 @@
         background-color: var(--kd-color-tags-hover-blue-dark);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-blue-dark);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -792,7 +792,7 @@
         background-color: var(--kd-color-tags-hover-critical-light);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-hover-critical-light);
         outline-color: var(--kd-color-border-variants-focus);
 
@@ -819,7 +819,7 @@
         background-color: var(--kd-color-tags-background-error-dark);
       }
 
-      &:focus {
+      &:focus-visible {
         background-color: var(--kd-color-tags-background-error-dark);
         outline-color: var(--kd-color-border-variants-focus);
 

--- a/src/components/reusable/toggleButton/toggleButton.scss
+++ b/src/components/reusable/toggleButton/toggleButton.scss
@@ -71,7 +71,7 @@ input {
     }
   }
 
-  &:focus:not(:hover) {
+  &:focus-visible:not(:hover) {
     outline-color: var(--kd-color-border-variants-focus);
 
     &:before {
@@ -79,7 +79,7 @@ input {
     }
   }
 
-  &:focus:hover {
+  &:focus-visible:hover {
     outline-color: var(--kd-color-border-variants-focus);
 
     &:before {

--- a/src/components/reusable/tooltip/tooltip.scss
+++ b/src/components/reusable/tooltip/tooltip.scss
@@ -23,7 +23,7 @@ button {
   outline: 2px solid transparent;
   transition: outline-color 150ms ease-out;
 
-  &:focus {
+  &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
   }
 }


### PR DESCRIPTION
## Summary

Replace all instances of CSS `:focus` with `:focus-visible`. Prevents focus rings from appearing unnecessarily on click of many elements like Buttons/Tabs, but maintains focus state when needed for example on focused input elements and when keyboard tabbing. I did a batch replace all and have not looked at every affected component.

More info: https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#focus_vs_focus-visible