### PR TITLE
fix(daterangepicker): values array clears on dateRangePickerDisabled toggle

### DIFF
--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -408,8 +408,20 @@ export class DateRangePicker extends FormMixin(LitElement) {
   override updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
 
+    if (changedProperties.has('dateRangePickerDisabled')) {
+      if (this.dateRangePickerDisabled) {
+        this.flatpickrInstance?.close();
+        return;
+      } else {
+        if (this.value[0] && this.value[1]) {
+          this.setInitialDates();
+        }
+      }
+    }
+
     if (
       changedProperties.has('value') &&
+      !this.dateRangePickerDisabled &&
       this.flatpickrInstance &&
       !this._isClearing
     ) {
@@ -485,14 +497,6 @@ export class DateRangePicker extends FormMixin(LitElement) {
         this.flatpickrInstance.destroy();
         this.initializeFlatpickr();
       }
-    }
-
-    if (
-      changedProperties.has('dateRangePickerDisabled') &&
-      this.dateRangePickerDisabled &&
-      this.flatpickrInstance
-    ) {
-      this.flatpickrInstance.close();
     }
   }
 


### PR DESCRIPTION
## Summary

**ISSUE**: dateRangePicker only, when you select a range and then toggle `dateRangePickerDisabled` to true, it clears the selected `values` array to `[null, null]`

**SOLUTION**: prioritize `dateRangePickerDisabled` in `updated()` so that it only closes the flatpickr UI and no longer resets array

## Screenshots
### Previously
<img width="354" alt="Screenshot 2025-03-21 at 8 30 08 AM" src="https://github.com/user-attachments/assets/cfc61cf0-8aa2-4fb0-8765-203622ebf8d9" />
<br/>

### With `updated()` improvements
<img width="347" alt="Screenshot 2025-03-21 at 8 30 23 AM" src="https://github.com/user-attachments/assets/c5abee35-0f76-45df-8b3d-bb71fc244a3f" />