### PR TITLE
feat: token updates for disabled state

### DIFF
--- a/src/common/scss/form-input.scss
+++ b/src/common/scss/form-input.scss
@@ -19,7 +19,7 @@
   }
 
   [disabled] & {
-    color: var(--kd-color-text-link-level-disabled);
+    color: var(--kd-color-text-level-disabled);
   }
 }
 
@@ -111,7 +111,7 @@ textarea {
   &[disabled] {
     background: var(--kd-color-background-forms-disabled);
     border: none;
-    color: var(--kd-color-text-link-level-disabled);
+    color: var(--kd-color-text-level-disabled);
     cursor: not-allowed;
 
     &[invalid] {
@@ -151,10 +151,10 @@ textarea {
   }
 
   [disabled] & {
-    color: var(--kd-color-text-link-level-disabled);
+    color: var(--kd-color-text-level-disabled);
 
     span svg {
-      color: var(--kd-color-text-link-level-disabled);
+      color: var(--kd-color-text-level-disabled);
     }
   }
 
@@ -168,7 +168,7 @@ textarea {
   color: var(--kd-color-status-error-dark);
 
   [disabled] & {
-    color: var(--kd-color-text-link-level-disabled);
+    color: var(--kd-color-text-level-disabled);
   }
 }
 
@@ -176,7 +176,7 @@ textarea {
   color: var(--kd-color-background-success);
 
   [disabled] & {
-    color: var(--kd-color-text-link-level-disabled);
+    color: var(--kd-color-text-level-disabled);
   }
 }
 
@@ -213,7 +213,7 @@ textarea {
     color: var(--kd-color-text-forms-label-secondary);
     margin-top: 13px;
     [disabled] & {
-      color: var(--kd-color-text-link-level-disabled);
+      color: var(--kd-color-text-level-disabled);
     }
   }
 }
@@ -239,7 +239,7 @@ textarea {
   }
 
   [disabled] & {
-    color: var(--kd-color-text-link-level-disabled);
+    color: var(--kd-color-text-level-disabled);
   }
 
   span,
@@ -256,6 +256,6 @@ textarea {
   margin-bottom: 8px;
 
   [disabled] & {
-    color: var(--kd-color-text-link-level-disabled);
+    color: var(--kd-color-text-level-disabled);
   }
 }

--- a/src/common/scss/form-input.scss
+++ b/src/common/scss/form-input.scss
@@ -43,7 +43,7 @@
       color: var(--kd-color-icon-disabled);
     }
   }
-  .input-icon[disabled] {
+  .input-icon.is-disabled {
     color: var(--kd-color-icon-disabled);
   }
 }

--- a/src/common/scss/form-input.scss
+++ b/src/common/scss/form-input.scss
@@ -43,6 +43,9 @@
       color: var(--kd-color-icon-disabled);
     }
   }
+  .input-icon[disabled] {
+    color: var(--kd-color-icon-disabled);
+  }
 }
 
 .options-text {

--- a/src/components/reusable/checkbox/checkbox.scss
+++ b/src/components/reusable/checkbox/checkbox.scss
@@ -21,7 +21,7 @@ label {
   }
 
   &[disabled] {
-    color: var(--kd-color-text-link-level-disabled);
+    color: var(--kd-color-text-level-disabled);
   }
 }
 
@@ -124,16 +124,16 @@ input {
   }
 
   &[disabled] {
-    background: var(--kd-color-background-ui-hollow-default);
+    background: var(--kd-color-background-forms-disabled);
     border-color: var(--kd-color-border-ui-disabled);
 
     &:checked {
-      background: var(--kd-color-background-ui-default-disabled);
+      background: var(--kd-color-background-forms-disabled);
       border-color: transparent;
 
       &::before {
         transform: scale(1);
-        background: var(--kd-color-background-ui-hollow-default);
+        background: var(--kd-color-icon-disabled);
         mask: $checkbox-mask;
         -webkit-mask: $checkbox-mask;
         mask-size: contain;
@@ -197,7 +197,7 @@ input[type='checkbox']:indeterminate:disabled {
     width: 10px;
     height: 8px;
     transform: scale(1);
-    background: var(--kd-color-background-ui-hollow-default);
+    background: var(--kd-color-icon-disabled);
     mask: linear-gradient(transparent 3px, #000 3px 5px, transparent 5px);
     -webkit-mask: linear-gradient(
       transparent 3px,

--- a/src/components/reusable/datePicker/datepicker.ts
+++ b/src/components/reusable/datePicker/datepicker.ts
@@ -360,7 +360,10 @@ export class DatePicker extends FormMixin(LitElement) {
                   >
                 </kyn-button>
               `
-            : html`<span class="input-icon" ?disabled=${this.datePickerDisabled}
+            : html`<span
+                class="input-icon ${this.datePickerDisabled
+                  ? 'is-disabled'
+                  : ''}"
                 >${unsafeSVG(calendarIcon)}</span
               >`}
         </div>

--- a/src/components/reusable/datePicker/datepicker.ts
+++ b/src/components/reusable/datePicker/datepicker.ts
@@ -360,7 +360,9 @@ export class DatePicker extends FormMixin(LitElement) {
                   >
                 </kyn-button>
               `
-            : html`<span class="input-icon">${unsafeSVG(calendarIcon)}</span>`}
+            : html`<span class="input-icon" ?disabled=${this.datePickerDisabled}
+                >${unsafeSVG(calendarIcon)}</span
+              >`}
         </div>
 
         ${this.caption

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -401,7 +401,11 @@ export class DateRangePicker extends FormMixin(LitElement) {
                   </span>
                 </kyn-button>
               `
-            : html`<span class="input-icon">${unsafeSVG(calendarIcon)}</span>`}
+            : html`<span
+                class="input-icon"
+                ?disabled=${this.dateRangePickerDisabled}
+                >${unsafeSVG(calendarIcon)}</span
+              >`}
         </div>
 
         ${this.caption

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -402,8 +402,8 @@ export class DateRangePicker extends FormMixin(LitElement) {
                 </kyn-button>
               `
             : html`<span
-                class="input-icon"
-                ?disabled=${this.dateRangePickerDisabled}
+                class="input-icon
+                ${this.dateRangePickerDisabled ? 'is-disabled' : ''}"
                 >${unsafeSVG(calendarIcon)}</span
               >`}
         </div>

--- a/src/components/reusable/radioButton/radioButton.scss
+++ b/src/components/reusable/radioButton/radioButton.scss
@@ -10,7 +10,7 @@ label {
   gap: 10px;
 
   &[disabled] {
-    color: var(--kd-color-text-link-level-disabled);
+    color: var(--kd-color-text-level-disabled);
   }
 }
 
@@ -131,25 +131,25 @@ input {
   }
 
   &[disabled] {
-    border-color: var(--kd-color-text-link-level-disabled);
+    border-color: var(--kd-color-border-ui-disabled);
     outline-color: transparent;
     opacity: 0.5;
     cursor: not-allowed;
 
-    &::before {
-      background: var(--kd-color-background-ui-default-disabled);
-    }
-
     &[invalid] {
       border-color: var(--kd-color-border-ui-disabled);
     }
-  }
 
-  &[disabled][checked] {
-    border-color: var(--kd-color-border-ui-disabled);
+    &:not(:checked) {
+      background: var(--kd-color-background-forms-disabled);
+    }
 
-    &::before {
-      background: var(--kd-color-background-ui-default-disabled);
+    &[checked] {
+      border-color: var(--kd-color-border-ui-disabled);
+
+      &::before {
+        background: var(--kd-color-background-ui-default-disabled);
+      }
     }
   }
 }

--- a/src/components/reusable/timepicker/timepicker.ts
+++ b/src/components/reusable/timepicker/timepicker.ts
@@ -318,7 +318,9 @@ export class TimePicker extends FormMixin(LitElement) {
                   </span>
                 </kyn-button>
               `
-            : html`<span class="input-icon">${unsafeSVG(clockIcon)}</span>`}
+            : html`<span class="input-icon" ?disabled=${this.timepickerDisabled}
+                >${unsafeSVG(clockIcon)}</span
+              >`}
         </div>
         ${this.caption
           ? html`<div

--- a/src/components/reusable/timepicker/timepicker.ts
+++ b/src/components/reusable/timepicker/timepicker.ts
@@ -318,7 +318,10 @@ export class TimePicker extends FormMixin(LitElement) {
                   </span>
                 </kyn-button>
               `
-            : html`<span class="input-icon" ?disabled=${this.timepickerDisabled}
+            : html`<span
+                class="input-icon ${this.timepickerDisabled
+                  ? 'is-disabled'
+                  : ''}"
                 >${unsafeSVG(clockIcon)}</span
               >`}
         </div>

--- a/src/components/reusable/toggleButton/toggleButton.scss
+++ b/src/components/reusable/toggleButton/toggleButton.scss
@@ -112,14 +112,14 @@ input {
   }
 
   &[disabled] {
-    background-color: var(--kd-color-background-ui-default-disabled);
+    background-color: var(--kd-color-states-disabled);
 
     &:before {
       background-color: var(--kd-color-background-ui-hollow-default);
     }
 
     &:hover {
-      background-color: var(--kd-color-background-ui-default-disabled);
+      background-color: var(--kd-color-states-disabled);
 
       &:before {
         background-color: var(--kd-color-background-ui-hollow-default);
@@ -127,7 +127,7 @@ input {
     }
 
     &:active {
-      background-color: var(--kd-color-background-ui-default-disabled);
+      background-color: var(--kd-color-states-disabled);
 
       &:before {
         background-color: var(--kd-color-background-ui-hollow-default);


### PR DESCRIPTION
Updated color tokens for below components in disabled state:
![image](https://github.com/user-attachments/assets/80180553-f76a-4bcb-9abc-24140a3565dc)

<body>

  | Disabled State
-- | --
Placeholder Text | --kd-color-text-level-disabled
Input Text | --kd-color-text-level-disabled
Label | --kd-color-text-level-disabled
Background | --kd-color-background-forms-disabled
Border | None


</body>
</html>

## ADO Story or GitHub Issue Link

[AB#2213841](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2213841)

## Figma Link

[Link here](https://www.figma.com/design/rC5XdRnXVbDmu3vPN8tJ4q/2.1-Edinburgh?node-id=4738-15997&p=f&m=dev)

