### PR TITLE
fix: fix to bubble up on-toggle event from sources-feedback component

### DIFF
--- a/src/components/ai/sourcesFeedback/aiSourcesFeedback.ts
+++ b/src/components/ai/sourcesFeedback/aiSourcesFeedback.ts
@@ -367,6 +367,8 @@ export class AISourcesFeedback extends LitElement {
           feedbackOpened: this.feedbackOpened,
           selectedFeedbackType: this._selectedFeedbackType,
         },
+        bubbles: true,
+        composed: true,
       })
     );
   }


### PR DESCRIPTION
Added fix to bubble up on-toggle event from kyn-ai-sources-feedback component


[AB#2222370](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2222370)

