### PR TITLE
fix: focus state update

### DIFF
--- a/src/common/scss/form-input.scss
+++ b/src/common/scss/form-input.scss
@@ -63,7 +63,6 @@ textarea {
     outline-color 150ms ease-out;
   background: var(--kd-color-background-forms-default);
   outline: 2px solid transparent;
-  outline-offset: 2px;
 
   .ai-connected & {
     border-color: var(--kd-color-border-variants-ai);
@@ -76,6 +75,7 @@ textarea {
 
   &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
+    border-color: transparent;
   }
 
   &::placeholder {
@@ -212,6 +212,7 @@ textarea {
     @include typography.type-ui-02;
     color: var(--kd-color-text-forms-label-secondary);
     margin-top: 13px;
+
     [disabled] & {
       color: var(--kd-color-text-link-level-disabled);
     }

--- a/src/common/scss/form-input.scss
+++ b/src/common/scss/form-input.scss
@@ -63,6 +63,7 @@ textarea {
     outline-color 150ms ease-out;
   background: var(--kd-color-background-forms-default);
   outline: 2px solid transparent;
+  outline-offset: -2px;
 
   .ai-connected & {
     border-color: var(--kd-color-border-variants-ai);
@@ -75,7 +76,6 @@ textarea {
 
   &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
-    border-color: transparent;
   }
 
   &::placeholder {

--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -66,6 +66,7 @@ slot[name='icon']::slotted(*) {
 
   .dropdown:focus-within & {
     outline-color: var(--kd-color-border-variants-focus);
+    border-color: transparent;
   }
 
   &.inline {
@@ -74,6 +75,7 @@ slot[name='icon']::slotted(*) {
 
     &:hover {
       border-color: var(--kd-color-border-ui-hover);
+
       [disabled] & {
         border-color: transparent;
       }
@@ -138,6 +140,7 @@ slot[name='icon']::slotted(*) {
 
   [searchable] &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
+    border-color: transparent;
   }
 }
 

--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -66,7 +66,6 @@ slot[name='icon']::slotted(*) {
 
   .dropdown:focus-within & {
     outline-color: var(--kd-color-border-variants-focus);
-    border-color: transparent;
   }
 
   &.inline {

--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -140,7 +140,6 @@ slot[name='icon']::slotted(*) {
 
   [searchable] &:focus-visible {
     outline-color: var(--kd-color-border-variants-focus);
-    border-color: transparent;
   }
 }
 

--- a/src/components/reusable/numberInput/numberInput.scss
+++ b/src/components/reusable/numberInput/numberInput.scss
@@ -24,7 +24,7 @@ input {
   padding: 0 16px;
 
   &:focus-visible {
-    outline: 2px solid var(--kd-color-border-variants-focus);
+    outline-color: var(--kd-color-border-variants-focus);
   }
 
   &.size--sm {

--- a/src/components/reusable/numberInput/numberInput.scss
+++ b/src/components/reusable/numberInput/numberInput.scss
@@ -24,7 +24,7 @@ input {
   padding: 0 16px;
 
   &:focus-visible {
-    outline-color: transparent;
+    outline: 2px solid var(--kd-color-border-variants-focus);
   }
 
   &.size--sm {


### PR DESCRIPTION
## Summary

Focus state update for the following components are made:
1. Date and time pickers.
2. Text input.
3. Text area.
4. Search.
5. Dropdown.
6. Number input.

## ADO Story or GitHub Issue Link

fixes [AB#2223639](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2223639)

## Figma Link

[Focus state updates](https://www.figma.com/design/rC5XdRnXVbDmu3vPN8tJ4q/2.1-Edinburgh?node-id=5019-26666&m=dev)

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [x] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots

### Date picker
<img width="455" alt="Screenshot 2025-04-15 at 3 43 18 PM" src="https://github.com/user-attachments/assets/1bb1642c-b911-4b89-9184-6fc1151bd7cf" />

### Date range picker
<img width="730" alt="Screenshot 2025-04-15 at 3 43 27 PM" src="https://github.com/user-attachments/assets/0d73cb9a-ce96-4aa5-b6fa-b2bd40d49e75" />

### Dropdown
<img width="366" alt="Screenshot 2025-04-15 at 3 43 35 PM" src="https://github.com/user-attachments/assets/b1f305b1-9b04-481b-b264-d848976174aa" />

### Number input
<img width="415" alt="Screenshot 2025-04-15 at 3 43 53 PM" src="https://github.com/user-attachments/assets/ccc2a97b-b420-4391-b2bb-c031739634ce" />

### Search
<img width="386" alt="Screenshot 2025-04-15 at 3 44 02 PM" src="https://github.com/user-attachments/assets/d7731d72-9400-4863-b914-482adfb165f9" />

### Text area
<img width="359" alt="Screenshot 2025-04-15 at 3 44 11 PM" src="https://github.com/user-attachments/assets/90508ee0-0ce9-49cd-a04f-aa63630e6d8e" />

### Text input
<img width="359" alt="Screenshot 2025-04-15 at 3 44 18 PM" src="https://github.com/user-attachments/assets/ea6e19d2-76a1-42fc-ad4c-324f86af03ff" />

### Time picker
<img width="496" alt="Screenshot 2025-04-15 at 3 44 26 PM" src="https://github.com/user-attachments/assets/e5c81894-bc5c-44bc-9bf8-d3761f7f296d" />
