### PR TITLE
chore: update component figma links

### DIFF
--- a/src/components/ai/aiLaunchButton/aiLaunchButton.stories.js
+++ b/src/components/ai/aiLaunchButton/aiLaunchButton.stories.js
@@ -9,7 +9,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=26921-36252&p=f&t=ESE4CBROt5qtceXn-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-300055&p=f&m=dev',
     },
   },
   argTypes: {

--- a/src/components/ai/sourcesFeedback/aiSourcesFeedback.stories.js
+++ b/src/components/ai/sourcesFeedback/aiSourcesFeedback.stories.js
@@ -13,7 +13,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-304117&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-300053&p=f&m=dev',
     },
   },
 };

--- a/src/components/ai/sourcesFeedback/aiSourcesFeedback.stories.js
+++ b/src/components/ai/sourcesFeedback/aiSourcesFeedback.stories.js
@@ -10,7 +10,12 @@ import '../../reusable/textArea/textArea';
 export default {
   title: 'AI / Components / AI Sources Feedback',
   component: 'kyn-ai-sources-feedback',
-  parameters: {},
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-304117&m=dev',
+    },
+  },
 };
 
 const sourcesData = [

--- a/src/components/global/footer/footer.stories.js
+++ b/src/components/global/footer/footer.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/CQuDZEeLiuGiALvCWjAKlu/Applications---Component-Library?node-id=10033-1598&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-15300&p=f&m=dev',
     },
   },
   decorators: [

--- a/src/components/global/header/Header.stories.js
+++ b/src/components/global/header/Header.stories.js
@@ -40,7 +40,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/qnqPc99nECP6mrcGKE3CTA/Components-%26-Patterns?node-id=311-195&node-type=canvas&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-18794&m=dev',
     },
     // controls: {
     //   include: Object.keys(Header.args),

--- a/src/components/global/uiShell/uiShell.stories.js
+++ b/src/components/global/uiShell/uiShell.stories.js
@@ -17,7 +17,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-371547&p=f&m=dev',
+      url: '',
     },
   },
   decorators: [

--- a/src/components/global/uiShell/uiShell.stories.js
+++ b/src/components/global/uiShell/uiShell.stories.js
@@ -14,6 +14,12 @@ import sampleIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/c
 export default {
   title: 'Global Components/UI Shell',
   component: 'kyn-ui-shell',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-371547&p=f&m=dev',
+    },
+  },
   decorators: [
     (story) =>
       html`

--- a/src/components/reusable/accordion/Accordion.stories.js
+++ b/src/components/reusable/accordion/Accordion.stories.js
@@ -16,6 +16,12 @@ export default {
   title: 'Components/Accordion',
   component: 'kyn-accordion',
   subcomponents: { 'kyn-accordion-item': 'kyn-accordion-item' },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-346870&p=f&m=dev',
+    },
+  },
 };
 
 const args = {
@@ -67,13 +73,6 @@ export const Accordion = {
         </kyn-accordion-item>
       </kyn-accordion>
     `;
-  },
-};
-
-Accordion.parameters = {
-  design: {
-    type: 'figma',
-    url: 'https://www.figma.com/file/5TqtPa7KWfhJbQv6ELnbqf/Foundation?node-id=707%3A2396&mode=dev',
   },
 };
 

--- a/src/components/reusable/avatar/avatar.stories.js
+++ b/src/components/reusable/avatar/avatar.stories.js
@@ -19,6 +19,6 @@ export const Avatar = {
 Avatar.parameters = {
   design: {
     type: 'figma',
-    url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Component-Library-for-Dev?node-id=215%3A2099&mode=dev',
+    url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-350776&m=dev',
   },
 };

--- a/src/components/reusable/avatar/avatar.stories.js
+++ b/src/components/reusable/avatar/avatar.stories.js
@@ -19,6 +19,6 @@ export const Avatar = {
 Avatar.parameters = {
   design: {
     type: 'figma',
-    url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-350776&m=dev',
+    url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-302033&m=dev',
   },
 };

--- a/src/components/reusable/breadcrumbs/breadcrumbs.stories.js
+++ b/src/components/reusable/breadcrumbs/breadcrumbs.stories.js
@@ -9,7 +9,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Component-Library-for-Dev?node-id=459%3A39033&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-363919&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/button/Button.stories.js
+++ b/src/components/reusable/button/Button.stories.js
@@ -103,7 +103,7 @@ export const Button = {
 Button.parameters = {
   design: {
     type: 'figma',
-    url: 'https://www.figma.com/file/5TqtPa7KWfhJbQv6ELnbqf/Foundation?node-id=72%3A18796&mode=dev',
+    url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-364159&p=f&m=dev',
   },
 };
 

--- a/src/components/reusable/card/card.stories.js
+++ b/src/components/reusable/card/card.stories.js
@@ -19,7 +19,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/5TqtPa7KWfhJbQv6ELnbqf/Foundation---Component-Library?node-id=5842%3A4589&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-371547&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/checkbox/checkbox.stories.js
+++ b/src/components/reusable/checkbox/checkbox.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Component-Library-for-Dev?node-id=62%3A1137&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-370429&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/checkbox/checkboxGroup.stories.js
+++ b/src/components/reusable/checkbox/checkboxGroup.stories.js
@@ -15,7 +15,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Component-Library-for-Dev?node-id=32%3A2346&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-370464&m=dev',
     },
   },
 };

--- a/src/components/reusable/datePicker/datepicker.stories.js
+++ b/src/components/reusable/datePicker/datepicker.stories.js
@@ -13,7 +13,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/branch/qMpff4GuFUEcsMUkvacS3U/Applications---Component-Library?node-id=19723-26652&node-type=canvas&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-372464&p=f&m=dev',
     },
   },
   argTypes: {

--- a/src/components/reusable/daterangepicker/daterangepicker.stories.js
+++ b/src/components/reusable/daterangepicker/daterangepicker.stories.js
@@ -13,7 +13,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/branch/qMpff4GuFUEcsMUkvacS3U/Applications---Component-Library?node-id=19723-26652&node-type=canvas&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-376248&m=dev',
     },
   },
   argTypes: {

--- a/src/components/reusable/dropdown/dropdown.stories.js
+++ b/src/components/reusable/dropdown/dropdown.stories.js
@@ -20,7 +20,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Component-Library-for-Dev?node-id=383%3A2845&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-540521&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/errorBlock/errorBlock.stories.js
+++ b/src/components/reusable/errorBlock/errorBlock.stories.js
@@ -11,7 +11,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/Applications---Component-Library?node-id=17386-106044&node-type=canvas&t=VYrUi3e41lGwsAHM-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-7561&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/floatingContainer/floatingContainer.stories.js
+++ b/src/components/reusable/floatingContainer/floatingContainer.stories.js
@@ -12,7 +12,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: '',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-13940&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/globalFilter/globalFilter.stories.js
+++ b/src/components/reusable/globalFilter/globalFilter.stories.js
@@ -12,7 +12,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Applications-Specs-for-Devs?node-id=3101%3A467&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-104226&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/inlineConfirm/inlineConfirm.stories.js
+++ b/src/components/reusable/inlineConfirm/inlineConfirm.stories.js
@@ -9,6 +9,12 @@ import deleteIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/20/d
 export default {
   title: 'Components/Inline Confirm',
   component: 'kyn-inline-confirm',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-545901&p=f&m=dev',
+    },
+  },
   decorators: [
     (story) =>
       html`

--- a/src/components/reusable/link/Link.stories.js
+++ b/src/components/reusable/link/Link.stories.js
@@ -19,7 +19,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=19896-17163&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-546100&p=f&m=dev',
     },
   },
   argTypes: {

--- a/src/components/reusable/loaders/inline.stories.js
+++ b/src/components/reusable/loaders/inline.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/branch/qMpff4GuFUEcsMUkvacS3U/Applications---Component-Library?node-id=15313-10436&node-type=canvas&t=cy38tiFaz5uZuLBW-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-546569&p=f&m=dev',
     },
   },
   argTypes: {

--- a/src/components/reusable/loaders/loader.stories.js
+++ b/src/components/reusable/loaders/loader.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/branch/qMpff4GuFUEcsMUkvacS3U/Applications---Component-Library?node-id=15313-10436&node-type=canvas&t=cy38tiFaz5uZuLBW-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-546569&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/loaders/skeleton.stories.js
+++ b/src/components/reusable/loaders/skeleton.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/branch/qMpff4GuFUEcsMUkvacS3U/Applications---Component-Library?node-id=15313-10436&node-type=canvas&t=cy38tiFaz5uZuLBW-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-546569&p=f&m=dev',
     },
   },
   argTypes: {

--- a/src/components/reusable/modal/modal.stories.js
+++ b/src/components/reusable/modal/modal.stories.js
@@ -17,7 +17,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/uwR7B1xbaRXA5spwPvzzFO/Florence-Release?type=design&node-id=2252%3A2&mode=design&t=E0KHOCJHSb38i6RZ-1',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-546829&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/notification/notification.stories.js
+++ b/src/components/reusable/notification/notification.stories.js
@@ -25,7 +25,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/CQuDZEeLiuGiALvCWjAKlu/Applications---Component-Library?type=design&node-id=9370-44581&mode=design&t=LXc9LDk5mGkf8vnl-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-549977&p=f&m=dev',
     },
   },
 };
@@ -147,6 +147,10 @@ export const Toast = {
   parameters: {
     a11y: {
       disable: true,
+    },
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-213406&p=f&m=dev',
     },
   },
   decorators: [

--- a/src/components/reusable/numberInput/numberInput.stories.js
+++ b/src/components/reusable/numberInput/numberInput.stories.js
@@ -27,7 +27,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/Applications---Component-Library?node-id=14893-233109&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-550224&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/overflowMenu/overflowMenu.stories.js
+++ b/src/components/reusable/overflowMenu/overflowMenu.stories.js
@@ -17,7 +17,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Applications-Specs-for-Devs?node-id=2522%3A520713&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-551887&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/pagetitle/pageTitle.stories.js
+++ b/src/components/reusable/pagetitle/pageTitle.stories.js
@@ -15,7 +15,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/pQKkip0UrZqEbaGN2dQ3dY/Istanbul-Release?type=design&node-id=352-128746&mode=design&t=UYTWn3Fif4KMP6v3-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-551887&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/pagetitle/pageTitle.stories.js
+++ b/src/components/reusable/pagetitle/pageTitle.stories.js
@@ -15,7 +15,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-551887&p=f&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-552144&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/pagination/pagination.stories.js
+++ b/src/components/reusable/pagination/pagination.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-443899&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-383230&m=dev',
     },
   },
   argTypes: {
@@ -69,4 +69,11 @@ export const Skeleton = {
       ?hideNavigationButtons=${args.hideNavigationButtons}
     ></kyn-pagination-skeleton>
   `,
+};
+
+Skeleton.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-546635&m=dev',
+  },
 };

--- a/src/components/reusable/pagination/pagination.stories.js
+++ b/src/components/reusable/pagination/pagination.stories.js
@@ -5,6 +5,12 @@ import { action } from '@storybook/addon-actions';
 export default {
   title: 'Components/Pagination',
   component: 'kyn-pagination',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-443899&m=dev',
+    },
+  },
   argTypes: {
     pageSize: {
       options: [5, 10, 20, 30, 40, 50, 100],
@@ -56,13 +62,11 @@ export const Pagination = {
 
 export const Skeleton = {
   args,
-  render: (args) => {
-    return html`
-      <kyn-pagination-skeleton
-        ?hideItemsRange=${args.hideItemsRange}
-        ?hidePageSizeDropdown=${args.hidePageSizeDropdown}
-        ?hideNavigationButtons=${args.hideNavigationButtons}
-      ></kyn-pagination-skeleton>
-    `;
-  },
+  render: (args) => html`
+    <kyn-pagination-skeleton
+      ?hideItemsRange=${args.hideItemsRange}
+      ?hidePageSizeDropdown=${args.hidePageSizeDropdown}
+      ?hideNavigationButtons=${args.hideNavigationButtons}
+    ></kyn-pagination-skeleton>
+  `,
 };

--- a/src/components/reusable/progressBar/progressBar.stories.js
+++ b/src/components/reusable/progressBar/progressBar.stories.js
@@ -12,7 +12,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/AIX4LLzoDHnFCXzQCiPHJk/Vienna?node-id=4308-129&node-type=canvas&t=NIQViMjgDrgdLGdi-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-552295&p=f&m=dev',
     },
   },
   argTypes: {

--- a/src/components/reusable/radioButton/radioButton.stories.js
+++ b/src/components/reusable/radioButton/radioButton.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Component-Library-for-Dev?node-id=32%3A2346&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-553013&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/radioButton/radioButtonGroup.stories.js
+++ b/src/components/reusable/radioButton/radioButtonGroup.stories.js
@@ -11,7 +11,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Component-Library-for-Dev?node-id=32%3A2346&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-553013&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/search/search.stories.js
+++ b/src/components/reusable/search/search.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/6AovH7Iay9Y7BkpoL5975s/Applications-Specs-for-Devs?node-id=5115-28788&t=JlOHq5O66s36vTFm-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-554036&p=f&m=dev',
     },
   },
   argTypes: {

--- a/src/components/reusable/sideDrawer/sideDrawer.stories.js
+++ b/src/components/reusable/sideDrawer/sideDrawer.stories.js
@@ -15,7 +15,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/branch/qMpff4GuFUEcsMUkvacS3U/Applications---Component-Library?node-id=8451-17321&node-type=canvas&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=3-386839&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/splitButton/splitButton.stories.js
+++ b/src/components/reusable/splitButton/splitButton.stories.js
@@ -49,7 +49,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/ssZ3MSPHNv0qhIvdiY3rXi/Dubrovnik-Release?node-id=279-55369&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=3-388211&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/stepper/stepper.stories.js
+++ b/src/components/reusable/stepper/stepper.stories.js
@@ -326,3 +326,10 @@ export const StatusStepper = {
     `;
   },
 };
+
+StatusStepper.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-195258&p=f&m=dev',
+  },
+};

--- a/src/components/reusable/stepper/stepper.stories.js
+++ b/src/components/reusable/stepper/stepper.stories.js
@@ -25,7 +25,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/Applications---Component-Library?node-id=13321-23753&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=0-1&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/table/table.stories.ts
+++ b/src/components/reusable/table/table.stories.ts
@@ -41,7 +41,7 @@ const meta: Meta = {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-370429&p=f&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-382289&p=f&m=dev',
     },
   },
 };
@@ -473,7 +473,7 @@ export const ColumnSettings: Story = {
     },
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/P3l7EMKOWmohY4aqYfGh1e/Florence-Prototypes?type=design&node-id=0%3A1&mode=design&t=hWVdRJTz3EdL7ltN-1',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=3-414475&m=dev',
     },
   },
 };
@@ -515,7 +515,7 @@ export const Skeleton = {
     },
     design: {
       type: 'figma',
-      url: '',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-546635&m=dev',
     },
     argTypes: {
       rows: {

--- a/src/components/reusable/table/table.stories.ts
+++ b/src/components/reusable/table/table.stories.ts
@@ -41,7 +41,7 @@ const meta: Meta = {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/branch/qMpff4GuFUEcsMUkvacS3U/Applications---Component-Library?node-id=9379-209416&p=f&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-370429&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/table/table.stories.ts
+++ b/src/components/reusable/table/table.stories.ts
@@ -473,7 +473,7 @@ export const ColumnSettings: Story = {
     },
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=3-414475&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=3-414323&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/tabs/tabs.stories.js
+++ b/src/components/reusable/tabs/tabs.stories.js
@@ -27,9 +27,11 @@ export default {
     'kyn-tab': 'kyn-tab',
     'kyn-tab-panel': 'kyn-tab-panel',
   },
-  design: {
-    type: 'figma',
-    url: 'https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=7695-2985&m=dev',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=4-418328&p=f&m=dev',
+    },
   },
 };
 

--- a/src/components/reusable/tag/tag.stories.js
+++ b/src/components/reusable/tag/tag.stories.js
@@ -53,7 +53,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/pQKkip0UrZqEbaGN2dQ3dY/Istanbul-Release?type=design&node-id=8-9731&mode=design&t=nd4DTcgjxZCAgnB6-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=4-420751&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/tag/tagGroup.stories.js
+++ b/src/components/reusable/tag/tagGroup.stories.js
@@ -18,7 +18,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/pQKkip0UrZqEbaGN2dQ3dY/Istanbul-Release?type=design&node-id=8-9731&mode=design&t=nd4DTcgjxZCAgnB6-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=4-420751&p=f&m=dev',
     },
   },
 };
@@ -80,5 +80,12 @@ export const Skeleton = {
         )}
       </kyn-tag-group>
     `;
+  },
+};
+
+Skeleton.parameters = {
+  design: {
+    type: 'figma',
+    url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-546635&m=dev',
   },
 };

--- a/src/components/reusable/textArea/textArea.stories.js
+++ b/src/components/reusable/textArea/textArea.stories.js
@@ -6,6 +6,12 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 export default {
   title: 'Components/Text Area',
   component: 'kyn-text-area',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=4-420752&p=f&m=dev',
+    },
+  },
   argTypes: {
     minLength: {
       control: { type: 'number' },
@@ -75,11 +81,4 @@ AIConnected.args = {
   notResizeable: true,
   rows: 1,
   maxRowsVisible: 4,
-};
-
-TextArea.parameters = {
-  design: {
-    type: 'figma',
-    url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=4-420752&p=f&m=dev',
-  },
 };

--- a/src/components/reusable/textArea/textArea.stories.js
+++ b/src/components/reusable/textArea/textArea.stories.js
@@ -80,6 +80,6 @@ AIConnected.args = {
 TextArea.parameters = {
   design: {
     type: 'figma',
-    url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Component-Library-for-Dev?node-id=215%3A2099&mode=dev',
+    url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=4-420752&p=f&m=dev',
   },
 };

--- a/src/components/reusable/textInput/textInput.stories.js
+++ b/src/components/reusable/textInput/textInput.stories.js
@@ -84,7 +84,7 @@ export const TextInput = {
 TextInput.parameters = {
   design: {
     type: 'figma',
-    url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Component-Library-for-Dev?node-id=85%3A611&mode=dev',
+    url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=4-421381&p=f&m=dev',
   },
 };
 

--- a/src/components/reusable/timepicker/timepicker.stories.js
+++ b/src/components/reusable/timepicker/timepicker.stories.js
@@ -12,7 +12,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/CQuDZEeLiuGiALvCWjAKlu/branch/qMpff4GuFUEcsMUkvacS3U/Applications---Component-Library?node-id=19723-26652&node-type=canvas&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=1-373273&m=dev',
     },
   },
   argTypes: {

--- a/src/components/reusable/toggleButton/toggleButton.stories.js
+++ b/src/components/reusable/toggleButton/toggleButton.stories.js
@@ -11,7 +11,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Component-Library-for-Dev?node-id=62%3A4312&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=4-421519&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/tooltip/tooltip.stories.js
+++ b/src/components/reusable/tooltip/tooltip.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/6AovH7Iay9Y7BkpoL5975s/Applications-Specs-for-Devs?node-id=2897%3A2521&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=4-423746&p=f&m=dev',
     },
   },
 };

--- a/src/components/reusable/widget/widget.stories.js
+++ b/src/components/reusable/widget/widget.stories.js
@@ -17,7 +17,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/CQuDZEeLiuGiALvCWjAKlu/Applications---Component-Library?node-id=10395%3A701&mode=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=4-423936&p=f&m=dev',
     },
     a11y: {
       // disable violations flagged in chartjs-plugin-a11y-legend

--- a/src/stories/ai/aiAnswers.stories.js
+++ b/src/stories/ai/aiAnswers.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=29524-9666&p=f&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-300056&p=f&m=dev',
     },
   },
 };

--- a/src/stories/ai/aiChatPattern.stories.js
+++ b/src/stories/ai/aiChatPattern.stories.js
@@ -16,6 +16,12 @@ import { ChatHistory } from './chatHistory.stories.js';
 
 export default {
   title: 'AI/Patterns/Chat',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-300050&p=f&m=dev',
+    },
+  },
 };
 
 export const ChatModal = {

--- a/src/stories/ai/aiPrompts.stories.js
+++ b/src/stories/ai/aiPrompts.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=29524-9666&p=f&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-300056&p=f&m=dev',
     },
   },
 };

--- a/src/stories/ai/chatHistory.stories.js
+++ b/src/stories/ai/chatHistory.stories.js
@@ -13,7 +13,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: '',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-300051&p=f&m=dev',
     },
   },
 };

--- a/src/stories/ai/chatMessages.stories.js
+++ b/src/stories/ai/chatMessages.stories.js
@@ -4,6 +4,12 @@ import { Default as infoCard } from './infoCard.stories.js';
 
 export default {
   title: 'AI/Patterns/Chat',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-300050&p=f&m=dev',
+    },
+  },
 };
 
 export const ChatMessages = {

--- a/src/stories/ai/infoCard.stories.js
+++ b/src/stories/ai/infoCard.stories.js
@@ -12,7 +12,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=25977-942236&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-300054&p=f&m=dev',
     },
   },
 };

--- a/src/stories/ai/inputQuery.stories.js
+++ b/src/stories/ai/inputQuery.stories.js
@@ -5,18 +5,14 @@ import '../../components/reusable/button';
 import sendIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/send.svg';
 import stopIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/control-stop-filled.svg';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
-import { User, Skeleton } from './response.stories.js';
 import '../../components/reusable/notification';
-import updateIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/update.svg';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
-import aiResponse from '@kyndryl-design-system/shidoka-foundation/assets/svg/ai/indicator.svg';
 
 export default {
   title: 'AI/Patterns/Input Query',
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=26094-200279&t=ZNgmsCAVJz1EMzfR-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-300057&p=f&m=dev',
     },
   },
 };

--- a/src/stories/ai/response.stories.js
+++ b/src/stories/ai/response.stories.js
@@ -9,6 +9,12 @@ import '../../components/reusable/loaders/skeleton';
 
 export default {
   title: 'AI/Patterns/Response',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-300058&p=f&m=dev',
+    },
+  },
 };
 
 export const User = {

--- a/src/stories/carousel/carousel.stories.js
+++ b/src/stories/carousel/carousel.stories.js
@@ -15,7 +15,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/CQuDZEeLiuGiALvCWjAKlu/Applications---Component-Library?node-id=16511-29991&node-type=frame&m=dev',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-7558&p=f&m=dev',
     },
   },
   decorators: [

--- a/src/stories/forms.stories.js
+++ b/src/stories/forms.stories.js
@@ -17,6 +17,12 @@ import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Patterns/Forms',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-15301&p=f&m=dev',
+    },
+  },
 };
 
 export const Default = {

--- a/src/stories/vitalCard.stories.js
+++ b/src/stories/vitalCard.stories.js
@@ -8,7 +8,7 @@ export default {
   parameters: {
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/CQuDZEeLiuGiALvCWjAKlu/Applications---Component-Library?type=design&node-id=9941-18758&mode=design&t=N5Lw7kAKTAjoCa0x-0',
+      url: 'https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-297686&p=f&m=dev',
     },
   },
 };


### PR DESCRIPTION
## Summary

Updated storybook Design tab figma links to new component viewer file instances. 

```
parameters: {
   design: {
     type: 'figma',
     url: {{UPDATED_DESIGN_URL}},
   }
 },
 ```

## Notes

### Pending 🏗️ or Incomplete (link has been updated to new instance)
Accordion
Dropdown
Carousel
Footer
Tags
Progress Bar (only displaying Error state)

### No Dedicated  Figma instance
Avatar
AI Answers Pattern (only AI Prompts)
Card / Informational Card (`Container` Instance? -- only Marketplace, Vital, AI Cards exist in component viewer)
Pagination (temporarily pointing directly to pagination in Data Table)
Local Nav (in Stepper Figma file)
UI Shell
Code View

### No corresponding UI Story
Backdrop
Form Label