### PR TITLE
fix(dropdown): parellel tabbing focus fix

### DIFF
--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -64,7 +64,7 @@ slot[name='icon']::slotted(*) {
     padding-right: 80px;
   }
 
-  .dropdown:focus-within & {
+  .dropdown:focus-visible & {
     outline-color: var(--kd-color-border-variants-focus);
   }
 


### PR DESCRIPTION
## Summary

Brief summary describing the changes here.

## GitHub Issue Link

fixes #448 

## Figma Link

NA


## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

