### PR TITLE
fix: add missing success variant to toast notification story

### DIFF
--- a/src/components/reusable/notification/notification.stories.js
+++ b/src/components/reusable/notification/notification.stories.js
@@ -195,6 +195,7 @@ export const Toast = {
             <code>${args.timeout}</code> seconds.
           </div>
         </kyn-notification>
+
         <kyn-notification
           notificationTitle=${args.notificationTitle}
           assistiveNotificationTypeText="Default toast"
@@ -207,12 +208,26 @@ export const Toast = {
         >
           <div>I will disappear after (default) <code>8</code> seconds.</div>
         </kyn-notification>
+
         <kyn-notification
           notificationTitle=${args.notificationTitle}
           assistiveNotificationTypeText="Warning toast"
           notificationRole=${args.notificationRole}
           type="toast"
           tagStatus="warning"
+          ?hideCloseButton=${args.hideCloseButton}
+          @on-close=${(e) => action(e.type)(e)}
+          timeout=${12}
+        >
+          <div>I will disappear after <code>10</code> seconds.</div>
+        </kyn-notification>
+
+        <kyn-notification
+          notificationTitle=${args.notificationTitle}
+          assistiveNotificationTypeText="Success toast"
+          notificationRole=${args.notificationRole}
+          type="toast"
+          tagStatus="success"
           ?hideCloseButton=${args.hideCloseButton}
           @on-close=${(e) => action(e.type)(e)}
           timeout=${12}


### PR DESCRIPTION
## Summary

In going over the changes from Edinburgh for documentation with Jimmy, I realized that the 'Toast' variant in the Notifications stories was missing a `success` status toast example. This is just adding that in.

## Screenshots
<img width="456" alt="436223979-4af68db5-377d-4968-a2f1-1fab43ce7240" src="https://github.com/user-attachments/assets/9a74502b-4d2a-4c1c-acc1-fcacb733022b" />