### PR TITLE
fix(dropdown): multiple label fix on selected tags On hover

### DIFF
--- a/src/components/reusable/dropdown/dropdown.ts
+++ b/src/components/reusable/dropdown/dropdown.ts
@@ -396,7 +396,6 @@ export class Dropdown extends FormMixin(LitElement) {
                         role="listitem"
                         label=${tag.text}
                         ?disabled=${this.disabled}
-                        clearTagText="Clear Tag ${tag.text}"
                         @on-close=${() => this.handleTagClear(tag.value)}
                       ></kyn-tag>
                     `;


### PR DESCRIPTION
## Summary

RCA: Dropdown: Due to cleartext props passed from `kyn-dropdwon` in`kyn-tag` makes tag label duplicated. 

Solution: 
Removed `cleartext` from `kyn-dropdwon` in`kyn-tag`.

##  GitHub Issue Link

fixes https://github.com/kyndryl-design-system/shidoka-applications/issues/454

## Figma Link

NA


## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Testing Instructions

Provide guidance to reviewers/testers here.

## Screenshots

(if any)
