### PR TITLE
fix(badge-and-tag): Increased the side padding

### DIFF
--- a/src/components/reusable/badge/badge.scss
+++ b/src/components/reusable/badge/badge.scss
@@ -11,7 +11,7 @@
   display: flex;
   align-items: center;
   border-radius: 16px;
-  padding: 4px;
+  padding: 4px 8px;
   gap: 4px;
   max-width: 161px;
 

--- a/src/components/reusable/tag/tag.scss
+++ b/src/components/reusable/tag/tag.scss
@@ -856,12 +856,12 @@
 .tag--new {
   &-medium {
     height: 24px;
-    padding: 4px;
+    padding: 4px 8px;
   }
 
   &-small {
     height: 20px;
-    padding: 2px 4px;
+    padding: 2px 8px;
   }
 
   &-disable {


### PR DESCRIPTION
## Summary

Increased the side padding for badge and tag from `4px` to `8px`.

## ADO Story or GitHub Issue Link

NA

## Figma Link

[Badge](https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=34109-11382&m=dev)
[Tag](https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=21792-35948&p=f&m=dev)

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file
