### PR TITLE
fix(dropdown-option): prevent checkmark text overlap

### DIFF
--- a/src/components/reusable/dropdown/dropdownOption.scss
+++ b/src/components/reusable/dropdown/dropdownOption.scss
@@ -49,6 +49,17 @@
     text-overflow: ellipsis;
   }
 
+  span.text {
+    flex-shrink: 0;
+  }
+
+  span.check-icon {
+    display: flex;
+    margin-left: auto;
+    padding: 0.5rem 0.5rem 0.5rem 0;
+    color: var(--kd-color-icon-accent);
+  }
+
   slot[name='icon']::slotted(span) {
     display: flex;
   }
@@ -58,13 +69,6 @@ kyn-checkbox {
   display: inline-block;
   vertical-align: text-bottom;
   margin-right: 10px;
-}
-
-.check-icon {
-  display: flex;
-  margin-left: auto;
-  padding: 0.5rem;
-  color: var(--kd-color-icon-accent);
 }
 
 .remove-option {

--- a/src/components/reusable/dropdown/dropdownOption.ts
+++ b/src/components/reusable/dropdown/dropdownOption.ts
@@ -87,7 +87,7 @@ export class DropdownOption extends LitElement {
         @blur=${(e: any) => this.handleBlur(e)}
       >
         <slot name="icon"></slot>
-        <span>
+        <span class="text">
           ${this.multiple
             ? html`
                 <kyn-checkbox


### PR DESCRIPTION
## Summary

Prevent selected option checkmark from overlapping option text.
[
Reported in Teams](https://teams.microsoft.com/l/message/19:m15yXA3kC7fl9TvnIML-6DxhfDtwyoLJMu0nVAeddXQ1@thread.tacv2/1747128195526?tenantId=f260df36-bc43-424c-8f44-c85226657b01&groupId=6097bcb7-eb77-4588-9226-1430b9c803ab&parentMessageId=1747128195526&teamName=Shidoka%20Design%20System&channelName=General&createdTime=1747128195526)