### PR TITLE
fix(dropdown): selections and disabled options

### DIFF
--- a/src/components/reusable/dropdown/dropdown.stories.js
+++ b/src/components/reusable/dropdown/dropdown.stories.js
@@ -147,7 +147,7 @@ export const SingleSearchable = {
 };
 
 export const MultiSelect = {
-  args: { ...args, value: ['1'] },
+  args: { ...args, value: ['1', '3'] },
   render: (args) => {
     return html`
       <kyn-dropdown

--- a/src/components/reusable/dropdown/dropdown.stories.js
+++ b/src/components/reusable/dropdown/dropdown.stories.js
@@ -1,5 +1,6 @@
 import { useArgs } from '@storybook/preview-api';
 import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js';
+import { repeat } from 'lit/directives/repeat.js';
 import { html } from 'lit';
 import './index';
 import { action } from '@storybook/addon-actions';
@@ -453,8 +454,10 @@ export const AddNewOption = {
           tooltip
         </kyn-tooltip>
 
-        ${dropdownItems.map((item) => {
-          return html`
+        ${repeat(
+          dropdownItems,
+          (item) => item.value,
+          (item) => html`
             <kyn-dropdown-option
               value=${item.value}
               ?disabled=${item.disabled}
@@ -464,8 +467,8 @@ export const AddNewOption = {
               <span slot="icon">${unsafeSVG(infoIcon)}</span>
               ${item.text}
             </kyn-dropdown-option>
-          `;
-        })}
+          `
+        )}
       </kyn-dropdown>
     `;
   },

--- a/src/components/reusable/dropdown/dropdown.ts
+++ b/src/components/reusable/dropdown/dropdown.ts
@@ -384,6 +384,24 @@ export class Dropdown extends FormMixin(LitElement) {
                 : null}
 
               <div role="listbox" aria-labelledby="label-${this.name}">
+                ${this.multiple && this.selectAll
+                  ? html`
+                      <kyn-dropdown-option
+                        class="select-all"
+                        value="selectAll"
+                        multiple
+                        ?selected=${this.selectAllChecked}
+                        ?indeterminate=${this.selectAllIndeterminate}
+                        ?disabled=${this.disabled}
+                        @on-click=${(e: any) => {
+                          this.selectAllChecked = e.detail.selected;
+                        }}
+                      >
+                        ${this.selectAllText}
+                      </kyn-dropdown-option>
+                    `
+                  : null}
+
                 <slot
                   id="children"
                   @slotchange=${() => this.handleSlotChange()}
@@ -1108,6 +1126,8 @@ export class Dropdown extends FormMixin(LitElement) {
     this._onUpdated(changedProps);
 
     if (changedProps.has('value')) {
+      this._updateOptions();
+
       const Slot: any = this.shadowRoot?.querySelector('slot#children');
       const Options: Array<any> = Slot.assignedElements().filter(
         (option: any) => !option.disabled
@@ -1123,7 +1143,6 @@ export class Dropdown extends FormMixin(LitElement) {
       this.selectAllIndeterminate =
         SelectedOptions.length < Options.length && SelectedOptions.length > 0;
 
-      this._updateOptions();
       this._updateTags();
       this._updateSelectedText();
     }

--- a/src/components/reusable/dropdown/dropdown.ts
+++ b/src/components/reusable/dropdown/dropdown.ts
@@ -393,9 +393,6 @@ export class Dropdown extends FormMixin(LitElement) {
                         ?selected=${this.selectAllChecked}
                         ?indeterminate=${this.selectAllIndeterminate}
                         ?disabled=${this.disabled}
-                        @on-click=${(e: any) => {
-                          this.selectAllChecked = e.detail.selected;
-                        }}
                       >
                         ${this.selectAllText}
                       </kyn-dropdown-option>
@@ -782,7 +779,15 @@ export class Dropdown extends FormMixin(LitElement) {
 
     // clear values
     if (this.multiple) {
-      this.value = [];
+      const Slot: any = this.shadowRoot?.querySelector('slot#children');
+      const Options: Array<any> = Slot.assignedElements();
+      const DisabledSelectedOptions: Array<any> = Options.filter(
+        (option: any) => option.selected && option.disabled
+      ).map((option: any) => option.value);
+
+      this.value = DisabledSelectedOptions.length
+        ? DisabledSelectedOptions
+        : [];
     } else {
       this.value = '';
     }
@@ -956,15 +961,27 @@ export class Dropdown extends FormMixin(LitElement) {
 
   private _handleClick(e: any) {
     if (e.detail.value === 'selectAll') {
+      this.selectAllChecked = e.detail.selected;
+
+      const Slot: any = this.shadowRoot?.querySelector('slot#children');
+      const Options: Array<any> = Slot.assignedElements();
+      const DisabledSelectedOptions: Array<any> = Options.filter(
+        (option: any) => option.selected && option.disabled
+      ).map((option: any) => option.value);
+
       if (e.detail.selected) {
         this.value = this.options
-          .filter((option) => !option.disabled)
+          .filter(
+            (option) => !option.disabled || (option.disabled && option.selected)
+          )
           .map((option) => {
             return option.value;
           });
         this.assistiveText = 'Selected all items.';
       } else {
-        this.value = [];
+        this.value = DisabledSelectedOptions.length
+          ? DisabledSelectedOptions
+          : [];
         this.assistiveText = 'Deselected all items.';
       }
 

--- a/src/components/reusable/dropdown/dropdown.ts
+++ b/src/components/reusable/dropdown/dropdown.ts
@@ -476,8 +476,8 @@ export class Dropdown extends FormMixin(LitElement) {
                       <kyn-tag
                         role="listitem"
                         label=${tag.text}
-                        ?disabled=${this.disabled}
-                        @on-close=${() => this.handleTagClear(tag.value)}
+                        ?disabled=${this.disabled || tag.disabled}
+                        @on-close=${() => this.handleTagClear(tag)}
                       ></kyn-tag>
                     `;
                   })}
@@ -804,9 +804,9 @@ export class Dropdown extends FormMixin(LitElement) {
     this.dispatchEvent(event);
   }
 
-  private handleTagClear(value: string) {
+  private handleTagClear(tag: any) {
     // remove value
-    this.updateValue(value, false);
+    this.updateValue(tag.value, false);
     this._updateSelectedOptions();
     this.emitValue();
   }
@@ -1224,6 +1224,7 @@ export class Dropdown extends FormMixin(LitElement) {
             Tags.push({
               value: option.value,
               text: option.textContent,
+              disabled: option.disabled,
             });
           }
         });

--- a/src/components/reusable/dropdown/dropdownOption.ts
+++ b/src/components/reusable/dropdown/dropdownOption.ts
@@ -28,7 +28,7 @@ export class DropdownOption extends LitElement {
   /** Internal text strings.
    * @internal
    */
-  @state()
+  @property({ type: Boolean })
   selected = false;
 
   /** Option disabled state. */
@@ -168,7 +168,6 @@ export class DropdownOption extends LitElement {
   }
 
   private handleClick(e: Event) {
-    console.log('blah');
     // prevent click if disabled
     if (this.disabled) {
       return;


### PR DESCRIPTION
## Summary

A handful of fixes to work around selection/deselection when disabled and disabled + selected options are involved.

1. Clear All tag will not remove disabled selected options
2. Select All option somehow went missing, and I've restored that and excluded disabled options from it's behavior.
3. Tags for disabled options will now be disabled also.