### PR TITLE
fix(dropdown): restore open upwards class

### DIFF
--- a/src/components/reusable/dropdown/dropdown.ts
+++ b/src/components/reusable/dropdown/dropdown.ts
@@ -353,7 +353,11 @@ export class Dropdown extends FormMixin(LitElement) {
 
             <div
               id="options"
-              class=${classMap({ options: true, open: this.open })}
+              class=${classMap({
+                options: true,
+                open: this.open,
+                upwards: this._openUpwards,
+              })}
               aria-hidden=${!this.open}
               @keydown=${this.handleListKeydown}
               @blur=${this.handleListBlur}


### PR DESCRIPTION
## Summary

Upwards class was missing so dropdown was no longer opening upwards automatically when near the bottom of viewport.