### PR TITLE
fix: adjust max-width media query values to be more precise

### DIFF
--- a/src/components/global/header/headerFlyout.scss
+++ b/src/components/global/header/headerFlyout.scss
@@ -82,7 +82,7 @@
   }
 }
 
-@media (max-width: calc(42rem - 1px)) {
+@media (max-width: calc(42rem - 0.001px)) {
   .menu {
     width: 100%;
 

--- a/src/components/global/header/headerLink.scss
+++ b/src/components/global/header/headerLink.scss
@@ -148,7 +148,7 @@ kyn-text-input {
   margin-bottom: 6px;
 }
 
-@media (max-width: calc(42rem - 1px)) {
+@media (max-width: calc(42rem - 0.001px)) {
   .menu {
     width: 100%;
 

--- a/src/components/global/localNav/localNav.scss
+++ b/src/components/global/localNav/localNav.scss
@@ -5,7 +5,7 @@
 :host {
   display: block;
 
-  @media (max-width: calc(42rem - 1px)) {
+  @media (max-width: calc(42rem - 0.001px)) {
     position: sticky;
     top: 0;
     z-index: var(--kd-z-header);

--- a/src/components/global/localNav/localNavLink.scss
+++ b/src/components/global/localNav/localNavLink.scss
@@ -114,7 +114,7 @@ a {
     }
   }
 
-  @media (max-width: calc(42rem - 1px)) {
+  @media (max-width: calc(42rem - 0.001px)) {
     top: 0 !important;
     left: 0 !important;
   }

--- a/src/components/reusable/card/vitalCard.scss
+++ b/src/components/reusable/card/vitalCard.scss
@@ -79,7 +79,7 @@
     }
 
     &-text {
-      @media (max-width: calc(42rem - 1px)) {
+      @media (max-width: calc(42rem - 0.001px)) {
         @include visibility.sr-only;
       }
     }

--- a/src/components/reusable/errorBlock/errorBlock.scss
+++ b/src/components/reusable/errorBlock/errorBlock.scss
@@ -30,7 +30,7 @@
     flex-wrap: wrap;
     justify-content: center;
 
-    @media (max-width: calc(42rem - 1px)) {
+    @media (max-width: calc(42rem - 0.001px)) {
       kyn-button {
         width: 100%;
         flex-grow: 1;

--- a/src/components/reusable/modal/modal.scss
+++ b/src/components/reusable/modal/modal.scss
@@ -134,7 +134,7 @@ h1 {
   gap: 16px;
   margin-top: 32px;
 
-  @media (max-width: calc(42rem - 1px)) {
+  @media (max-width: calc(42rem - 0.001px)) {
     kyn-button {
       width: 100%;
       flex-grow: 1;

--- a/src/components/reusable/pagination/pagination-navigation-buttons.scss
+++ b/src/components/reusable/pagination/pagination-navigation-buttons.scss
@@ -10,7 +10,7 @@
 }
 
 .page-range {
-  @media (max-width: calc(42rem - 1px)) {
+  @media (max-width: calc(42rem - 0.001px)) {
     @include visibility.sr-only;
   }
 }

--- a/src/components/reusable/sideDrawer/sideDrawer.scss
+++ b/src/components/reusable/sideDrawer/sideDrawer.scss
@@ -150,7 +150,7 @@ form {
   flex-wrap: wrap;
   gap: 16px;
 
-  @media (max-width: calc(42rem - 1px)) {
+  @media (max-width: calc(42rem - 0.001px)) {
     kyn-button {
       width: 100%;
       flex-grow: 1;

--- a/src/components/reusable/table/table-footer.scss
+++ b/src/components/reusable/table/table-footer.scss
@@ -14,7 +14,7 @@
   }
 }
 
-@media (max-width: calc(42rem - 1px)) {
+@media (max-width: calc(42rem - 0.001px)) {
   ::slotted(kyn-pagination) {
     order: -1;
   }

--- a/src/stories/sampleCardComponents/vitalCard.scss
+++ b/src/stories/sampleCardComponents/vitalCard.scss
@@ -81,7 +81,7 @@
     }
 
     &-text {
-      @media (max-width: calc(42rem - 1px)) {
+      @media (max-width: calc(42rem - 0.001px)) {
         @include visibility.sr-only;
       }
     }


### PR DESCRIPTION
## Summary

Windows display scaling values other than 100% can cause viewport size/media query calculation issues. Our max-width queries had a "gap" of 1px where styles could potentially not be applied. Making them more precise erases that gap. Ex: 671.999px (42rem - .001px) vs 671px (42rem - 1px).

Ref: https://stackoverflow.com/a/63647803/23719206