### PR TITLE
feat: breadcrump readability

### DIFF
--- a/src/components/reusable/breadcrumbs/breadcrumbs.scss
+++ b/src/components/reusable/breadcrumbs/breadcrumbs.scss
@@ -9,7 +9,7 @@
 
   ::slotted(strong) {
     @include typography.type-ui-02;
-    font-weight: 500;
+    font-weight: 400;
   }
 
   ::slotted(kyn-link) {

--- a/src/components/reusable/breadcrumbs/breadcrumbs.stories.js
+++ b/src/components/reusable/breadcrumbs/breadcrumbs.stories.js
@@ -18,8 +18,8 @@ export const Breadcrumbs = {
   render: () => {
     return html`
       <kyn-breadcrumbs role="navigation" aria-label="Breadcrumb">
-        <kyn-link standalone href="/path">Level 1</kyn-link>
-        <kyn-link standalone href="/path">Level 2</kyn-link>
+        <kyn-link standalone kind="breadcrumb" href="/path">Level 1</kyn-link>
+        <kyn-link standalone kind="breadcrumb" href="/path">Level 2</kyn-link>
         <strong aria-current="page">Current page</strong>
       </kyn-breadcrumbs>
     `;
@@ -30,15 +30,15 @@ export const WithOverflow = {
   render: () => {
     return html`
       <kyn-breadcrumbs role="navigation" aria-label="Breadcrumb">
-        <kyn-link standalone href="/path">Level 1</kyn-link>
-        <kyn-link standalone href="/path">Level 2</kyn-link>
+        <kyn-link standalone kind="breadcrumb" href="/path">Level 1</kyn-link>
+        <kyn-link standalone kind="breadcrumb" href="/path">Level 2</kyn-link>
 
         <kyn-overflow-menu>
           <kyn-overflow-menu-item href="/path">Level 3</kyn-overflow-menu-item>
           <kyn-overflow-menu-item href="/path">Level 4</kyn-overflow-menu-item>
         </kyn-overflow-menu>
 
-        <kyn-link standalone href="/path">Level 5</kyn-link>
+        <kyn-link standalone kind="breadcrumb" href="/path">Level 5</kyn-link>
         <strong aria-current="page">Current page</strong>
       </kyn-breadcrumbs>
     `;

--- a/src/components/reusable/link/defs.ts
+++ b/src/components/reusable/link/defs.ts
@@ -3,6 +3,7 @@ export enum LINK_TYPES {
   SECONDARY = 'secondary',
   AI_CONNECTED = 'ai',
   SECONDARY_AI = 'secondary-ai',
+  BREADCRUMB = 'breadcrumb',
 }
 
 export enum LINK_SIZES {

--- a/src/components/reusable/link/link.scss
+++ b/src/components/reusable/link/link.scss
@@ -60,6 +60,24 @@
     }
   }
 
+  // Breadcrumb
+  &-breadcrumb {
+    font-weight: 400;
+    color: var(--kd-color-text-link-level-default);
+
+    &:hover {
+      color: var(--kd-color-text-link-level-hover);
+    }
+
+    &:focus-visible {
+      outline-color: var(--kd-color-border-variants-focus);
+    }
+
+    &:active {
+      color: var(--kd-color-text-link-level-pressed);
+    }
+  }
+
   // Link disable class
   &-disabled {
     cursor: not-allowed;

--- a/src/components/reusable/link/link.ts
+++ b/src/components/reusable/link/link.ts
@@ -83,6 +83,7 @@ export class Link extends LitElement {
         'kyn-link-text-primary': this.kind === LINK_TYPES.PRIMARY || !this.kind,
         'kyn-link-text-secondary': this.kind === LINK_TYPES.SECONDARY,
         'kyn-link-text-secondary-ai': this.kind === LINK_TYPES.SECONDARY_AI,
+        'kyn-link-text-breadcrumb': this.kind === LINK_TYPES.BREADCRUMB,
         'kyn-link-text-inline': !this.standalone,
         'kyn-link-text-standalone': this.standalone,
       });


### PR DESCRIPTION
## Summary

Storybook to match Figma design for Breadcrum -- requires `breadcrumb` specific link `kind` property to indicate a font-weight change from the default `500` to `400`

## Figma Link

* when available

## To Do

Discuss between UX and UI upon Brian's return

## Screenshots

### Previous
<img width="319" alt="Screenshot 2025-05-22 at 10 48 49 AM" src="https://github.com/user-attachments/assets/8ccc06a1-72d8-462e-a296-538f96af356a" />

<br/>

<img width="476" alt="Screenshot 2025-05-22 at 10 48 59 AM" src="https://github.com/user-attachments/assets/44d88bb7-fec1-470c-bace-f05a127203b4" />


### Proposed Change\
<img width="328" alt="Screenshot 2025-05-22 at 10 47 57 AM" src="https://github.com/user-attachments/assets/d78bae62-4d29-48cd-b5ea-39ce4f521b55" />

<img width="487" alt="Screenshot 2025-05-22 at 10 48 00 AM" src="https://github.com/user-attachments/assets/ec7e4ba3-bc5f-4896-ab93-cbd302b843a5" />