### PR TITLE
fix(grid): added color preset pattern

### DIFF
--- a/src/components/reusable/widget/gridstack.stories.js
+++ b/src/components/reusable/widget/gridstack.stories.js
@@ -204,6 +204,10 @@ export const Gridstack = {
 
 export const AddWidget = {
   render: () => {
-    return html` <new-widget-sample></new-widget-sample> `;
+    return html`
+      <new-widget-sample
+        @on-click=${(e) => action(e.type)(e)}
+      ></new-widget-sample>
+    `;
   },
 };

--- a/src/components/reusable/widget/sample/gridstack.newWidget.sample.ts
+++ b/src/components/reusable/widget/sample/gridstack.newWidget.sample.ts
@@ -385,7 +385,7 @@ export class NewWidgetSample extends LitElement {
                     : this.getImageBackgroundTemplate()}
                 </div>
                 <div class="bacground-image">
-                  <div class="bg_title">Background Image</div>
+                  <div class="bg_title">Background Color</div>
                   <div class="color-swatch">
                     ${this.formattedColorSwatches.map((color) => {
                       return html`

--- a/src/components/reusable/widget/sample/gridstack.newWidget.sample.ts
+++ b/src/components/reusable/widget/sample/gridstack.newWidget.sample.ts
@@ -416,6 +416,7 @@ export class NewWidgetSample extends LitElement {
       </kyn-side-drawer>
       <br />
       <br />
+      <br />
       <kyn-widget-gridstack
         .layout=${this.updateLayout}
         .gridstackConfig=${modifiedConfig}

--- a/src/components/reusable/widget/sample/gridstack.newWidget.sample.ts
+++ b/src/components/reusable/widget/sample/gridstack.newWidget.sample.ts
@@ -45,14 +45,12 @@ import { GridStack } from 'gridstack';
 type Breakpoint = 'max' | 'xl' | 'lg' | 'md' | 'sm';
 
 const colorSwatchArr = [
-  '#D9D9D9',
-  '#E8BA02',
-  '#2F808C',
-  'linear-gradient(180deg, #FF462D 0%, rgba(153, 42, 27, 0.00) 100%)',
-  '#9747FF',
-  '#4CDD84',
-  '#1D2125',
-  '#5FBEAC',
+  'linear-gradient(180deg, #2F808C 0%, var(--kd-color-background-page-default, #1D2125) 100%)',
+  'linear-gradient(180deg, #FF462D 0%, var(--kd-color-background-page-default, #1D2125) 100%)',
+  'linear-gradient(180deg, #4CDD84 0%, var(--kd-color-background-page-default, #1D2125) 100%)',
+  'linear-gradient(180deg, #101316 0%, var(--kd-color-background-page-default, #1D2125) 100%)',
+  'linear-gradient(180deg, #5FBEAC 0%, var(--kd-color-background-page-default, #1D2125) 100%)',
+  'linear-gradient(180deg, #E8BA02 0%, var(--kd-colo-background-page-default, #1D2125) 100%)',
 ];
 
 /**

--- a/src/components/reusable/widget/sample/gridstack.newWidget.sample.ts
+++ b/src/components/reusable/widget/sample/gridstack.newWidget.sample.ts
@@ -21,6 +21,7 @@ import recommendIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/1
 import deleteIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/20/delete.svg';
 import editIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/edit.svg';
 import splitIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/split.svg';
+import CheckMarkFilledIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/20/checkmark-filled.svg';
 
 import '../../overflowMenu';
 import '../../button';
@@ -42,6 +43,17 @@ import '../../fileUploader/fileUploader.sample';
 import { GridStack } from 'gridstack';
 
 type Breakpoint = 'max' | 'xl' | 'lg' | 'md' | 'sm';
+
+const colorSwatchArr = [
+  '#D9D9D9',
+  '#E8BA02',
+  '#2F808C',
+  'linear-gradient(180deg, #FF462D 0%, rgba(153, 42, 27, 0.00) 100%)',
+  '#9747FF',
+  '#4CDD84',
+  '#1D2125',
+  '#5FBEAC',
+];
 
 /**
  * New Widget sample.
@@ -196,6 +208,12 @@ export class NewWidgetSample extends LitElement {
 
   @state()
   updateLayout = SampleLayout;
+
+  @state()
+  formattedColorSwatches = colorSwatchArr.map((color) => ({
+    color: color,
+    selected: false,
+  }));
 
   override render() {
     const modifiedConfig = {
@@ -365,6 +383,31 @@ export class NewWidgetSample extends LitElement {
                         </div>
                       `
                     : this.getImageBackgroundTemplate()}
+                </div>
+                <div class="bacground-image">
+                  <div class="bg_title">Background Image</div>
+                  <div class="color-swatch">
+                    ${this.formattedColorSwatches.map((color) => {
+                      return html`
+                        <button
+                          class="preset-button"
+                          style="background:${color.color};"
+                          type="button"
+                          aria-label="Background Color"
+                          title="Background Color"
+                          name="Background Color"
+                          @click=${(e: Event) =>
+                            this._handleSelection(e, color.color)}
+                        >
+                          ${color.selected
+                            ? html`<span style="display:flex"
+                                >${unsafeSVG(CheckMarkFilledIcon)}</span
+                              >`
+                            : null}
+                        </button>
+                      `;
+                    })}
+                  </div>
                 </div>
               </div>
             </div>
@@ -686,6 +729,23 @@ export class NewWidgetSample extends LitElement {
   private handleUploadImageClick(e: any) {
     this.showFileUploader = !this.showFileUploader;
     action(e.type)(e);
+  }
+
+  private _handleSelection(e: Event, colorSelected: string) {
+    const button = e.target as HTMLButtonElement;
+    const isSelected = button.classList.contains('selected');
+    this.formattedColorSwatches = this.formattedColorSwatches.map((color) => {
+      return {
+        ...color,
+        selected: color.color === colorSelected ? !isSelected : false,
+      };
+    });
+    const event = new CustomEvent('on-click', {
+      detail: { value: colorSelected, origEvent: e },
+      bubbles: true,
+      composed: true,
+    });
+    this.dispatchEvent(event);
   }
 }
 

--- a/src/components/reusable/widget/sample/gridstack.newWidget.scss
+++ b/src/components/reusable/widget/sample/gridstack.newWidget.scss
@@ -166,3 +166,40 @@
   gap: 10px;
   flex: 1 0 0;
 }
+
+.color-swatch {
+  display: flex;
+  align-items: flex-start;
+  align-content: flex-start;
+  gap: 10px;
+  align-self: stretch;
+  flex-wrap: wrap;
+}
+.color-selector {
+  display: block;
+  border-radius: 50%;
+  outline: 1px solid var(--kd-color-border-accent-secondary);
+  width: 60px;
+  height: 60px;
+}
+
+.preset-button {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background-color: #d9d9d9;
+  border: 1px solid var(--kd-color-border-accent-secondary);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  cursor: pointer;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  span > svg {
+    fill: var(--kd-color-icon-primary);
+  }
+}
+.preset-button:focus-visible {
+  outline-color: var(--kd-color-border-button-primary-state-focused);
+}


### PR DESCRIPTION
## Summary

Added color preset pattern in Grid/Add widget/SideDrawer(Settings)

## ADO Story

[AB#2097838](https://dev.azure.com/Kyndryl/f7f7ab25-06ec-43dc-902d-dee2e157cebd/_workitems/edit/2097838)

## Figma Link

[Figma](https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=34761-21839&m=dev)



## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [x] Ran the `analyze` command to update Storybook docs.
- [x] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

