### PR TITLE
fix(dropdown): add min-width to options menu

### DIFF
--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -103,6 +103,7 @@ slot[name='icon']::slotted(*) {
   top: 100%;
   margin-top: 4px;
   width: 100%;
+  min-width: 120px;
   max-height: 280px;
   overflow-y: auto;
   outline: none;


### PR DESCRIPTION
## Summary

Prevent short text cutoff as [seen in this report](https://teams.microsoft.com/l/message/19:m15yXA3kC7fl9TvnIML-6DxhfDtwyoLJMu0nVAeddXQ1@thread.tacv2/1749145531724?tenantId=f260df36-bc43-424c-8f44-c85226657b01&groupId=6097bcb7-eb77-4588-9226-1430b9c803ab&parentMessageId=1749145531724&teamName=Shidoka%20Design%20System&channelName=General&createdTime=1749145531724).