### PR TITLE
fix(toggleButton): missing _validate function

### DIFF
--- a/src/components/reusable/toggleButton/toggleButton.ts
+++ b/src/components/reusable/toggleButton/toggleButton.ts
@@ -126,6 +126,27 @@ export class ToggleButton extends FormMixin(LitElement) {
       this._internals.setFormValue(this.checked ? this.value : null);
     }
   }
+
+  _validate(interacted: Boolean, report: Boolean) {
+    const Validity =
+      this.invalidText !== ''
+        ? { ...this._inputEl.validity, customError: true }
+        : this._inputEl.validity;
+    const ValidationMessage =
+      this.invalidText !== ''
+        ? this.invalidText
+        : this._inputEl.validationMessage;
+
+    this._internals.setValidity(Validity, ValidationMessage, this._inputEl);
+
+    if (interacted) {
+      this._internalValidationMsg = this._inputEl.validationMessage;
+    }
+
+    if (report) {
+      this._internals.reportValidity();
+    }
+  }
 }
 
 declare global {


### PR DESCRIPTION
## Summary

Fixes  user reported error

`TypeError: this._validate is not a function
      at s._onUpdated (../../../node_modules/@kyndryl-design-system/src/common/mixins/form-input.ts:92:14)
      at s.updated (../../../node_modules/@kyndryl-design-system/src/components/reusable/toggleButton/toggleButton.ts:122:10)
      at s._$AE (../../../node_modules/@kyndryl-design-system/node_modules/lit-element/node_modules/@lit/reactive-element/reactive-element.js:6:5137)
      at s.performUpdate (../../../node_modules/@kyndryl-design-system/node_modules/lit-element/node_modules/@lit/reactive-element/reactive-element.js:6:4917)
      at scheduleUpdate (../../../node_modules/@kyndryl-design-system/node_modules/lit-element/node_modules/@lit/reactive-element/reactive-element.js:6:4499)
      at s._$Ej (../../../node_modules/@kyndryl-design-system/node_modules/lit-element/node_modules/@lit/reactive-element/reactive-element.js:6:4407)`
