### PR TITLE
fix(toggleButton): typeerror fix

### DIFF
--- a/src/components/reusable/toggleButton/toggleButton.ts
+++ b/src/components/reusable/toggleButton/toggleButton.ts
@@ -127,11 +127,13 @@ export class ToggleButton extends FormMixin(LitElement) {
     }
   }
 
-  _validate(interacted: Boolean, report: Boolean) {
+  // ignore warning, FormMixin requires this method
+  private _validate(interacted: boolean, report: boolean) {
     const Validity =
       this.invalidText !== ''
         ? { ...this._inputEl.validity, customError: true }
         : this._inputEl.validity;
+
     const ValidationMessage =
       this.invalidText !== ''
         ? this.invalidText
@@ -142,7 +144,6 @@ export class ToggleButton extends FormMixin(LitElement) {
     if (interacted) {
       this._internalValidationMsg = this._inputEl.validationMessage;
     }
-
     if (report) {
       this._internals.reportValidity();
     }


### PR DESCRIPTION
additional typing added to fix error below, which is persisting:

`TypeError: this._validate is not a function
      at s._onUpdated (../../../node_modules/@kyndryl-design-system/src/common/mixins/form-input.ts:92:14)
      at s.updated (../../../node_modules/@kyndryl-design-system/src/components/reusable/toggleButton/toggleButton.ts:122:10)
      at s._$AE (../../../node_modules/@kyndryl-design-system/node_modules/lit-element/node_modules/@lit/reactive-element/reactive-element.js:6:5137)
      at s.performUpdate (../../../node_modules/@kyndryl-design-system/node_modules/lit-element/node_modules/@lit/reactive-element/reactive-element.js:6:4917)
      at scheduleUpdate (../../../node_modules/@kyndryl-design-system/node_modules/lit-element/node_modules/@lit/reactive-element/reactive-element.js:6:4499)
      at s._$Ej (../../../node_modules/@kyndryl-design-system/node_modules/lit-element/node_modules/@lit/reactive-element/reactive-element.js:6:4407)`

