### PR TITLE
fix(textInput): only show X clear button on search when value is present

### DIFF
--- a/src/components/reusable/textInput/textInput.ts
+++ b/src/components/reusable/textInput/textInput.ts
@@ -213,7 +213,7 @@ export class TextInput extends FormMixin(LitElement) {
                 </kyn-button>
               `
             : null}
-          ${this.value === 'search' && !this.readonly
+          ${this.type === 'search' && this.value !== '' && !this.readonly
             ? html`
                 <kyn-button
                   ?disabled=${this.disabled}


### PR DESCRIPTION
## Summary

Correct conditional to display clear 'X' button only when `type` of textInput is `'search'` and when value is not an empty string.
