### PR TITLE
fix(bug-495): clear button sizing in 'sm' input only

### DIFF
--- a/src/components/reusable/textInput/textInput.scss
+++ b/src/components/reusable/textInput/textInput.scss
@@ -98,3 +98,8 @@ input[type='password']::-ms-clear {
   transform: translateY(-50%);
   cursor: pointer;
 }
+
+.input-wrapper input.size--sm ~ ::part(button) {
+  width: 20px;
+  height: 20px;
+}


### PR DESCRIPTION
## ADO Story or GitHub Issue Link

#495 
[AB#2326776](https://dev.azure.com/Kyndryl/f7f7ab25-06ec-43dc-902d-dee2e157cebd/_workitems/edit/2326776)

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Testing Instructions

Provide guidance to reviewers/testers here.

## Screenshots

### Before
<img width="346" alt="Screenshot 2025-06-12 at 12 31 07 PM" src="https://github.com/user-attachments/assets/467b3957-dbd9-44da-9fa9-335ab0fc9d92" />

### After
<img width="350" alt="Screenshot 2025-06-12 at 12 27 56 PM" src="https://github.com/user-attachments/assets/268c5e6e-9a57-4d8b-bda1-ee86cab80a77" />
<br/>
<img width="417" alt="Screenshot 2025-06-12 at 12 38 29 PM" src="https://github.com/user-attachments/assets/94a70423-b3ba-4652-84b4-496e212a4901" />