### PR TITLE
fix(dropdown): checkbox click fix on Safari

### DIFF
--- a/src/components/reusable/dropdown/dropdown.ts
+++ b/src/components/reusable/dropdown/dropdown.ts
@@ -308,7 +308,7 @@ export class Dropdown extends FormMixin(LitElement) {
                   e.preventDefault();
                 }
               }}
-              @blur=${(e: any) => this.handleButtonBlur(e)}
+              @blur=${(e: any) => e.stopPropagation()}
             >
               ${this.multiple && this.value.length
                 ? html`
@@ -338,7 +338,7 @@ export class Dropdown extends FormMixin(LitElement) {
                       aria-disabled=${this.disabled}
                       @keydown=${(e: any) => this.handleSearchKeydown(e)}
                       @input=${(e: any) => this.handleSearchInput(e)}
-                      @blur=${(e: any) => this.handleSearchBlur(e)}
+                      @blur=${(e: any) => e.stopPropagation()}
                       @click=${(e: any) => this.handleSearchClick(e)}
                     />
                   `
@@ -848,33 +848,6 @@ export class Dropdown extends FormMixin(LitElement) {
   private handleSearchClick(e: any) {
     e.stopPropagation();
     this.open = true;
-  }
-
-  private handleButtonBlur(e: any) {
-    // don't blur if entering listbox or search input
-    if (
-      e.relatedTarget?.localName !== 'kyn-dropdown-option' &&
-      !e.relatedTarget?.classList.contains('options') &&
-      !e.relatedTarget?.classList.contains('search') &&
-      !e.relatedTarget?.closest('.add-option')
-    ) {
-      this.open = false;
-    }
-    this._validate(true, false);
-  }
-
-  private handleSearchBlur(e: any) {
-    // don't blur if entering listbox of button
-    if (
-      !e.relatedTarget ||
-      (e.relatedTarget?.localName !== 'kyn-dropdown-option' &&
-        !e.relatedTarget?.classList.contains('options') &&
-        !e.relatedTarget?.classList.contains('select') &&
-        !e.relatedTarget?.closest('.add-option'))
-    ) {
-      this.open = false;
-    }
-    this._validate(true, false);
   }
 
   private handleSearchKeydown(e: any) {


### PR DESCRIPTION
## Summary

**On Safari** - Clicking on checkbox on dropdown options was closing the dropdown options

RCA : In Safari , click on `kyn-checkbox` considers outside interaction which causes the closing panel without checked checkbox. 


## GitHub Issue Link

[AB#2319652](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2319652)

https://github.com/kyndryl-design-system/shidoka-applications/issues/491

## Figma Link

NA

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


