### PR TITLE
feat(invite user email): new pattern

### DIFF
--- a/src/stories/inviteUserEmail.stories.js
+++ b/src/stories/inviteUserEmail.stories.js
@@ -1,11 +1,11 @@
 import { html } from 'lit';
 import { render } from 'lit-html';
-import '../components/reusable/textArea';
+import '../components/reusable/textInput';
 import '../components/reusable/tag';
 
 export default {
   title: 'Patterns/Invite User Email',
-  component: 'kyn-text-area',
+  component: 'kyn-text-input',
 };
 
 const users = [
@@ -34,12 +34,12 @@ export const InviteUserEmail = () => {
   const update = () => {
     render(
       html`
-        <kyn-text-area
+        <kyn-text-input
           rows="5"
           placeholder="Enter user email and press Enter"
           @keydown=${onKeydown}
           style="width: 95%; max-width: 600px;"
-        ></kyn-text-area>
+        ></kyn-text-input>
 
         ${tags.length
           ? html`

--- a/src/stories/inviteUserEmail.stories.js
+++ b/src/stories/inviteUserEmail.stories.js
@@ -1,0 +1,74 @@
+import { html } from 'lit';
+import { render } from 'lit-html';
+import '../components/reusable/textArea';
+import '../components/reusable/tag';
+
+export default {
+  title: 'Patterns/Invite User Email',
+  component: 'kyn-text-area',
+};
+
+const users = [
+  'john.doe@example.com',
+  'jane.smith@example.com',
+  'user@example.com',
+];
+
+export const InviteUserEmail = () => {
+  const container = document.createElement('div');
+  let tags = [];
+
+  const onKeydown = (e) => {
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    const textarea = e.target;
+    const parts = textarea.value.split(',');
+    const newEmail = parts.pop().trim();
+    if (!newEmail) return;
+    const found = users.includes(newEmail);
+    tags = [...tags, { email: newEmail, found }];
+    textarea.value = '';
+    update();
+  };
+
+  const update = () => {
+    render(
+      html`
+        <kyn-text-area
+          rows="5"
+          placeholder="Enter user email and press Enter"
+          @keydown=${onKeydown}
+          style="width: 95%; max-width: 600px;"
+        ></kyn-text-area>
+
+        ${tags.length
+          ? html`
+              <kyn-tag-group
+                tagSize="md"
+                filter
+                style="margin-top: 10px;"
+                .textStrings=${{ showAll: 'Show all', showLess: 'Show less' }}
+              >
+                ${tags.map(
+                  ({ email, found }) => html`
+                    <kyn-tag
+                      status=${found ? 'success' : 'error'}
+                      class=${found
+                        ? 'tag-status--success'
+                        : 'tag-status--error'}
+                      tagColor=${found ? 'spruce' : 'lilac'}
+                      label=${email}
+                    ></kyn-tag>
+                  `
+                )}
+              </kyn-tag-group>
+            `
+          : null}
+      `,
+      container
+    );
+  };
+
+  update();
+  return container;
+};


### PR DESCRIPTION
## Summary

Currently extending `<kyn-text-input>` component to create a new pattern. However, html`<input/>`s only accept text, no other html content as indicated by the design, so a workaround is needed. 

#### Options as I currently see it:
1. ⁠keep the <kyn-text-area> as the real text-storage, but hide its border and place the <kyn-tag>s inside the same container so they look like they’re in the field. they would be contained within the same box, but appended near the bottom or top, never inside of the textarea itself
2. create an entirely new standalone component (more work managing selections, copy/paste, but it’s the only way to get real in-line HTML elements inside the “input.”)

## ADO Story

[AB#2295799](https://dev.azure.com/Kyndryl/f7f7ab25-06ec-43dc-902d-dee2e157cebd/_workitems/edit/2295799)

## Figma Link

When available

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [x] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots
*In progress:
<img width="642" alt="Screenshot 2025-06-13 at 3 30 20 PM" src="https://github.com/user-attachments/assets/a31a249c-890c-42d3-a018-2c76b87e43ef" />

