### PR TITLE
fix(dropdown): info icon placement update

### DIFF
--- a/src/components/reusable/dropdown/dropdownOption.scss
+++ b/src/components/reusable/dropdown/dropdownOption.scss
@@ -69,7 +69,7 @@
 kyn-checkbox {
   display: inline-block;
   vertical-align: text-bottom;
-  margin-right: 10px;
+  margin-right: -4px;
 }
 
 .remove-option {

--- a/src/components/reusable/dropdown/dropdownOption.ts
+++ b/src/components/reusable/dropdown/dropdownOption.ts
@@ -111,6 +111,7 @@ export class DropdownOption extends LitElement {
               `}
         </span>
 
+        <slot name="icon" style="display:flex"></slot>
         ${this.selected && !this.multiple
           ? html` <span class="check-icon">${unsafeSVG(checkIcon)}</span> `
           : this.allowAddOption && this.removable
@@ -133,8 +134,6 @@ export class DropdownOption extends LitElement {
               </kyn-button>
             `
           : null}
-
-        <slot name="icon"></slot>
       </div>
     `;
   }

--- a/src/components/reusable/dropdown/dropdownOption.ts
+++ b/src/components/reusable/dropdown/dropdownOption.ts
@@ -86,7 +86,6 @@ export class DropdownOption extends LitElement {
         @pointerup=${(e: any) => this.handleClick(e)}
         @blur=${(e: any) => this.handleBlur(e)}
       >
-        <slot name="icon"></slot>
         <span class="text">
           ${this.multiple
             ? html`
@@ -99,10 +98,11 @@ export class DropdownOption extends LitElement {
                   notFocusable
                   .indeterminate=${this.indeterminate}
                 >
-                  <slot
-                    @slotchange=${(e: any) => this.handleSlotChange(e)}
-                  ></slot>
                 </kyn-checkbox>
+
+                <slot
+                  @slotchange=${(e: any) => this.handleSlotChange(e)}
+                ></slot>
               `
             : html`
                 <slot
@@ -133,6 +133,8 @@ export class DropdownOption extends LitElement {
               </kyn-button>
             `
           : null}
+
+        <slot name="icon"></slot>
       </div>
     `;
   }


### PR DESCRIPTION
## Summary

Dropdown panel: info icon placement to the right

## ADO Story

[AB#2330799](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2330799)

## Figma Link

[Link here](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2311739)


## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file



## Screenshots

(if any)
