### PR TITLE
fix(bug-502): radio button fill in disabled state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
-        "@kyndryl-design-system/shidoka-foundation": "^2.4.10",
+        "@kyndryl-design-system/shidoka-foundation": "^2.4.13",
         "@kyndryl-design-system/shidoka-icons": "^2.12.1",
         "@lit/context": "^1.1.0",
         "deepmerge-ts": "^7.1.0",
@@ -3573,9 +3573,9 @@
       }
     },
     "node_modules/@kyndryl-design-system/shidoka-foundation": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-2.4.10.tgz",
-      "integrity": "sha512-gxnDfhdgoGJuER1e50/iN08IswL8xxlYMpp4HxuGTneEkzFCcdUAnO1fraT5YftB8yh7NZzcOiIGPMGPxEOv2g=="
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-2.4.13.tgz",
+      "integrity": "sha512-6BbRIuhtX0BZncbLxaMwwXVynWEeqbw3xNah8KLJtDrhKGv4Luh+osXliMAQLyTt2Mfx/0Lg/gA+d8SR4hMF1A=="
     },
     "node_modules/@kyndryl-design-system/shidoka-icons": {
       "version": "2.12.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepare": "npx husky install"
   },
   "dependencies": {
-    "@kyndryl-design-system/shidoka-foundation": "^2.4.10",
+    "@kyndryl-design-system/shidoka-foundation": "^2.4.13",
     "@kyndryl-design-system/shidoka-icons": "^2.12.1",
     "@lit/context": "^1.1.0",
     "deepmerge-ts": "^7.1.0",

--- a/src/components/reusable/radioButton/radioButton.scss
+++ b/src/components/reusable/radioButton/radioButton.scss
@@ -145,10 +145,11 @@ input {
     }
 
     &[checked] {
+      border-width: 2px;
       border-color: var(--kd-color-border-ui-disabled);
 
       &::before {
-        background: var(--kd-color-background-ui-default-disabled);
+        background: var(--kd-color-border-ui-disabled);
       }
     }
   }


### PR DESCRIPTION
## Summary

1) Fix radioButton styles in disabled state so that `::before` fill matches the border color, match border width in disabled state to match Figma.

2) Upgrade foundation to latest

## ADO Story or GitHub Issue Link

#502 

[AB#2332782](https://dev.azure.com/Kyndryl/f7f7ab25-06ec-43dc-902d-dee2e157cebd/_workitems/edit/2332782)

## Figma Link

[Original Radio Button Figma File](https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?node-id=4193-260554&m=dev)

## Notes

- current Figma token for `::before` is set to `--kd-color-background-ui-default-disabled`, which does not match the border token (`--kd-color-border-ui-disabled`) and is difficult to distinguish from the background color in either dark or light mode.
- will raise the issue with UX, but changed the token to match the border token

## To Do

- follow up with UX once token is corrected and make adjustments as needed to `radioButton.scss`

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots
<img width="242" alt="Screenshot 2025-06-17 at 10 10 57 AM" src="https://github.com/user-attachments/assets/88c82933-0dde-4691-89bd-e29cadbbde68" />

<img width="224" alt="Screenshot 2025-06-17 at 10 10 53 AM" src="https://github.com/user-attachments/assets/6c117862-ccf9-40f4-8ce5-f4cd20d952e0" />

