### PR TITLE
fix(globalFilter):  slotted buttons converted to ghost to match figma

### DIFF
--- a/src/components/reusable/globalFilter/globalFilter.chart.sample.ts
+++ b/src/components/reusable/globalFilter/globalFilter.chart.sample.ts
@@ -132,7 +132,7 @@ export class SampleFilterChartComponent extends LitElement {
         >
           <kyn-button
             slot="anchor"
-            kind="tertiary"
+            kind="ghost"
             size="small"
             iconPosition="left"
           >

--- a/src/components/reusable/globalFilter/globalFilter.table.sample.ts
+++ b/src/components/reusable/globalFilter/globalFilter.table.sample.ts
@@ -131,7 +131,7 @@ export class SampleFilterTableComponent extends LitElement {
         >
           <kyn-button
             slot="anchor"
-            kind="tertiary"
+            kind="ghost"
             size="small"
             iconPosition="left"
             tabindex="-1"


### PR DESCRIPTION
## Summary

Convert buttons in table and chart Global Filter examples from secondary to ghost / small to match Figma.

## Figma Link

[Figma Link](https://www.figma.com/design/9Q2XfTSxfzTXfNe2Bi8KDS/Component-Viewer?node-id=7-105777&m=dev)
