### PR TITLE
fix(header category): heading font-weight

### DIFF
--- a/src/components/global/header/headerCategory.scss
+++ b/src/components/global/header/headerCategory.scss
@@ -12,6 +12,7 @@
 }
 
 .heading {
+  @include typography.type-ui-03;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -19,12 +20,10 @@
   font-weight: 500;
   text-transform: uppercase;
   padding: 20px 12px 0 12px;
-  // border-bottom: 1px solid var(--kd-color-border-level-tertiary);
 
   &.left-padding {
     padding-left: 36px;
   }
-  @include typography.type-ui-03;
 }
 
 slot[name='icon']::slotted(*) {


### PR DESCRIPTION
## Summary

Placement of `@include typography.type-ui-03;` in scss styles was overriding the desired font-weight (500) and setting it to the default font-weight for that typography (400).

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## Screenshots
<img width="1188" alt="Screenshot 2025-06-30 at 2 21 46 PM" src="https://github.com/user-attachments/assets/5325caac-04ba-4e6b-b1ec-a9081317460d" />