### PR TITLE
fix(header categories): additional font-weight corrections

### DIFF
--- a/src/components/global/header/headerFlyout.scss
+++ b/src/components/global/header/headerFlyout.scss
@@ -39,11 +39,11 @@
 }
 
 .menu-label {
+  @include typography.type-ui-03;
   color: var(--kd-color-text-title-secondary);
   font-weight: 500;
   text-transform: uppercase;
   padding: 12px 12px 0px 12px;
-  @include typography.type-ui-03;
 }
 
 .menu {

--- a/src/components/global/localNav/localNavDivider.scss
+++ b/src/components/global/localNav/localNavDivider.scss
@@ -16,6 +16,7 @@
 }
 
 .heading {
+  @include typography.type-ui-03;
   color: var(--kd-color-text-title-secondary);
   font-weight: 500;
   text-transform: uppercase;
@@ -23,6 +24,4 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-
-  @include typography.type-ui-03;
 }

--- a/src/components/global/localNav/localNavLink.scss
+++ b/src/components/global/localNav/localNavLink.scss
@@ -230,6 +230,7 @@ a {
 }
 
 .category {
+  @include typography.type-ui-03;
   font-weight: 500;
   color: var(--kd-color-text-level-tertiary-bold);
   text-transform: uppercase;
@@ -239,8 +240,6 @@ a {
   @media (min-width: 42rem) {
     display: none;
   }
-
-  @include typography.type-ui-03;
 }
 
 .text {

--- a/src/components/reusable/avatar/avatar.scss
+++ b/src/components/reusable/avatar/avatar.scss
@@ -2,6 +2,7 @@
 @use '@kyndryl-design-system/shidoka-foundation/scss/mixins/typography.scss';
 
 .avatar-wrapper {
+  @include typography.type-ui-03;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -14,6 +15,4 @@
     border-color 150ms ease-out;
   white-space: nowrap;
   overflow: hidden;
-
-  @include typography.type-ui-03;
 }


### PR DESCRIPTION
## Summary

Additional corrections to instances where the default font-weight of the typography @include was overriding the desired font-weight for header categories

## Screenshots
<img width="344" alt="Screenshot 2025-06-30 at 3 09 37 PM" src="https://github.com/user-attachments/assets/32aca4d9-6c29-4928-bd5b-4e2067c67d88" />
<img width="591" alt="Screenshot 2025-06-30 at 3 09 24 PM" src="https://github.com/user-attachments/assets/603b8c8f-764e-42a1-943d-c6bb72a76f2d" />
