### PR TITLE
fix(daterangepicker): less aggressive event propagation stops

### DIFF
--- a/src/common/helpers/flatpickr.ts
+++ b/src/common/helpers/flatpickr.ts
@@ -103,8 +103,6 @@ export function preventFlatpickrOpen(
   setShouldFlatpickrOpen: (value: boolean) => void
 ): void {
   event.preventDefault();
-  event.stopPropagation();
-  event.stopImmediatePropagation();
   setShouldFlatpickrOpen(false);
 }
 


### PR DESCRIPTION
## Summary

Less aggressive `stopEventPropagation` + `stopImmediatePropagation` (removed) to resolve issue consuming devs were experiencing where clicking the date range picker input(s) was not launching the flatpickr calendar UI.