### PR TITLE
fix(modal): match cancel buttonn to figma -- secondary

### DIFF
--- a/src/common/helpers/flatpickr.ts
+++ b/src/common/helpers/flatpickr.ts
@@ -103,6 +103,8 @@ export function preventFlatpickrOpen(
   setShouldFlatpickrOpen: (value: boolean) => void
 ): void {
   event.preventDefault();
+  event.stopPropagation();
+  event.stopImmediatePropagation();
   setShouldFlatpickrOpen(false);
 }
 

--- a/src/components/reusable/modal/modal.ts
+++ b/src/components/reusable/modal/modal.ts
@@ -191,7 +191,7 @@ export class Modal extends LitElement {
                           <kyn-button
                             class="action-button"
                             value="cancel"
-                            kind="tertiary"
+                            kind="secondary"
                             @click=${(e: Event) =>
                               this._closeModal(e, 'cancel')}
                           >


### PR DESCRIPTION
## Summary

External UX designer alerted us in office hours that the modal 'Cancel' button in storybook did not match the current state of the Figma file, which wasn't updated along with the other button changes.

This PR simply converts the 'Cancel' button from a `tertiary` to a `secondary` button.