### PR TITLE
fix(globalFilter, informationalCard): button updates

### DIFF
--- a/src/components/reusable/button/button.scss
+++ b/src/components/reusable/button/button.scss
@@ -11,6 +11,8 @@
 
 // Base Button Styles
 .kd-btn {
+  @include typography.type-body-02;
+  font-weight: 500;
   transition: outline-color 0.2s ease-in-out, color 0.2s ease-in-out,
     background-color 0.2s ease-in-out, border-color 0.2s ease-out;
   white-space: nowrap;
@@ -26,7 +28,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  @include typography.type-body-02;
 
   &.icon-only {
     min-width: initial;

--- a/src/components/reusable/globalFilter/globalFilter.sample.ts
+++ b/src/components/reusable/globalFilter/globalFilter.sample.ts
@@ -162,7 +162,7 @@ export class SampleFilterComponent extends LitElement {
 
         <kyn-button
           slot="actions"
-          kind="tertiary"
+          kind="secondary"
           size="small"
           iconPosition="left"
           @on-click=${(e: any) => this._handleCustomAction(e)}

--- a/src/stories/sampleCardComponents/card.content.sample.ts
+++ b/src/stories/sampleCardComponents/card.content.sample.ts
@@ -46,7 +46,7 @@ export class SampleCardStoryContentComponent extends LitElement {
             <!-- Example : Card action button -->
             <div class="card-action-btn-class">
               <kyn-button
-                kind="tertiary"
+                kind="ghost"
                 size="small"
                 iconPosition="center"
                 description="Action"
@@ -97,14 +97,14 @@ export class SampleCardStoryContentComponent extends LitElement {
         <div class="card-link-elements">
           <kyn-button
             href="#"
-            kind="tertiary"
+            kind="outline"
             size="small"
             @click=${(e: Event) => e.preventDefault()}
             >Link 1</kyn-button
           >
           <kyn-button
             href="#"
-            kind="tertiary"
+            kind="outline"
             size="small"
             @click=${(e: Event) => e.preventDefault()}
             >Link 2</kyn-button


### PR DESCRIPTION
## Summary

Following button audit comparing Figma and Storybook, UX requested updates to action buttons in the following components:
- [Global filter](https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?m=auto&node-id=7720-34595&t=veX4YwcpPEg3xEvG-1)
- [Informational card](https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library-2.0?m=auto&node-id=8998-63516&t=veX4YwcpPEg3xEvG-1)

**Additional change** (double-checking with Marco and Diana):
I noticed that the font-weight in buttons across the board was 500, currently defaulting to default font-weight of `@include typography.type-body-02;` (400)

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots
#### Button Updates
<img width="761" alt="Screenshot 2025-07-02 at 12 53 59 PM" src="https://github.com/user-attachments/assets/046b6fdb-d1a9-457d-8f1c-445434575beb" />

#### Informational Card

<img width="394" alt="Screenshot 2025-07-02 at 12 53 46 PM" src="https://github.com/user-attachments/assets/72f23edf-af11-4e7f-bfc0-710f74371b78" />

#### Global Filter
<img width="762" alt="Screenshot 2025-07-02 at 12 53 06 PM" src="https://github.com/user-attachments/assets/52c00d6b-f179-48ac-957d-e7fbee47af8b" />


