### PR TITLE
fix(datepickers): handle when minDate year === maxDate year

### DIFF
--- a/src/common/helpers/flatpickr.ts
+++ b/src/common/helpers/flatpickr.ts
@@ -761,23 +761,19 @@ export function setCalendarAttributes(
 }
 
 export function hideEmptyYear(): void {
-  const currentMonth = document.querySelector(
-    '.flatpickr-current-month span.cur-month'
-  ) as HTMLElement;
+  // force year input to always be visible - don't hide it even when min === max
   document.querySelectorAll('.numInputWrapper').forEach((wrapper) => {
     const yearInput = wrapper.querySelector(
       '.numInput.cur-year'
     ) as HTMLInputElement;
-    if (
-      yearInput &&
-      yearInput.min &&
-      yearInput.max &&
-      yearInput.min === yearInput.max
-    ) {
-      (wrapper as HTMLElement).style.display = 'none';
+    if (yearInput) {
+      (wrapper as HTMLElement).style.display = '';
 
-      if (currentMonth) {
-        currentMonth.style.marginLeft = 'auto';
+      yearInput.style.display = '';
+      yearInput.disabled = false;
+
+      if (!yearInput.hasAttribute('tabindex')) {
+        yearInput.tabIndex = 0;
       }
     }
   });

--- a/src/components/reusable/datePicker/datepicker.stories.js
+++ b/src/components/reusable/datePicker/datepicker.stories.js
@@ -134,6 +134,17 @@ DateWithTime.args = {
 };
 DateWithTime.storyName = 'Date + Time (Hindi Locale)';
 
+export const MinMaxDateExample = Template.bind({});
+MinMaxDateExample.args = {
+  ...DatePickerDefault.args,
+  name: 'date-time-picker',
+  dateFormat: 'Y-m-d',
+  minDate: '2024-01-01',
+  maxDate: '2024-12-31',
+  caption: '',
+  label: 'Min and Max dates set',
+};
+
 export const DatePickerMultiple = Template.bind({});
 DatePickerMultiple.args = {
   ...DatePickerDefault.args,

--- a/src/components/reusable/datePicker/datepicker.ts
+++ b/src/components/reusable/datePicker/datepicker.ts
@@ -547,12 +547,22 @@ export class DatePicker extends FormMixin(LitElement) {
       this.requestUpdate();
     }
 
-    if (
-      changedProperties.has('defaultDate') &&
-      this.flatpickrInstance &&
-      !this._isClearing
-    ) {
-      this.debouncedUpdate();
+    if (changedProperties.has('defaultDate') && !this._isClearing) {
+      if (this.defaultDate && !this.value) {
+        const processedDates = this.processDefaultDates(this.defaultDate);
+        if (processedDates && processedDates.length > 0) {
+          if (this.mode === 'multiple') {
+            this.value = [...processedDates];
+          } else {
+            this.value = processedDates[0];
+          }
+          this.requestUpdate();
+        }
+      }
+
+      if (this.flatpickrInstance) {
+        this.debouncedUpdate();
+      }
     }
 
     if (changedProperties.has('disable')) {

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -814,44 +814,59 @@ export class DateRangePicker extends FormMixin(LitElement) {
       }
     }
 
-    if (changedProperties.has('defaultDate') && this.flatpickrInstance) {
-      const dates = this.processDefaultDates(this.defaultDate);
-      this.value =
-        dates.length === 2
-          ? ([dates[0], dates[1]] as [Date, Date])
-          : dates.length === 1
-          ? ([dates[0], null] as [Date, null])
-          : ([null, null] as [null, null]);
-      if (Array.isArray(this.defaultDate) && this.defaultDate.length === 2) {
-        if (
-          this.rangeEditMode === DateRangeEditableMode.START &&
-          !this.defaultDate[0] &&
-          this.defaultDate[1]
-        ) {
-          const processedDate = this.processDefaultDates([this.defaultDate[1]]);
-          if (processedDate.length === 1) {
-            this.value = [null, processedDate[0]];
-          }
-        } else if (
-          this.rangeEditMode === DateRangeEditableMode.END &&
-          this.defaultDate[0] &&
-          !this.defaultDate[1]
-        ) {
-          const processedDate = this.processDefaultDates([this.defaultDate[0]]);
-          if (processedDate.length === 1) {
-            this.value = [processedDate[0], null];
+    if (changedProperties.has('defaultDate')) {
+      if (
+        this.defaultDate &&
+        (!this.value || this.value.every((v) => v === null))
+      ) {
+        const dates = this.processDefaultDates(this.defaultDate);
+        this.value =
+          dates.length === 2
+            ? ([dates[0], dates[1]] as [Date, Date])
+            : dates.length === 1
+            ? ([dates[0], null] as [Date, null])
+            : ([null, null] as [null, null]);
+
+        if (Array.isArray(this.defaultDate) && this.defaultDate.length === 2) {
+          if (
+            this.rangeEditMode === DateRangeEditableMode.START &&
+            !this.defaultDate[0] &&
+            this.defaultDate[1]
+          ) {
+            const processedDate = this.processDefaultDates([
+              this.defaultDate[1],
+            ]);
+            if (processedDate.length === 1) {
+              this.value = [null, processedDate[0]];
+            }
+          } else if (
+            this.rangeEditMode === DateRangeEditableMode.END &&
+            this.defaultDate[0] &&
+            !this.defaultDate[1]
+          ) {
+            const processedDate = this.processDefaultDates([
+              this.defaultDate[0],
+            ]);
+            if (processedDate.length === 1) {
+              this.value = [processedDate[0], null];
+            }
           }
         }
+
+        this.updateFormValue();
+        this.requestUpdate();
       }
 
-      this.flatpickrInstance.destroy();
-      this.initializeFlatpickr().then(() => {
-        if (this._inputEl && this.flatpickrInstance) {
-          this._inputEl.value = this.flatpickrInstance.input.value;
-          this.flatpickrInstance.redraw();
-          this.updateFormValue();
-        }
-      });
+      if (this.flatpickrInstance) {
+        this.flatpickrInstance.destroy();
+        this.initializeFlatpickr().then(() => {
+          if (this._inputEl && this.flatpickrInstance) {
+            this._inputEl.value = this.flatpickrInstance.input.value;
+            this.flatpickrInstance.redraw();
+            this.updateFormValue();
+          }
+        });
+      }
     }
 
     if (changedProperties.has('disable')) {

--- a/src/components/reusable/timepicker/timepicker.ts
+++ b/src/components/reusable/timepicker/timepicker.ts
@@ -416,6 +416,20 @@ export class TimePicker extends FormMixin(LitElement) {
       changedProperties.has('defaultHour') ||
       changedProperties.has('defaultMinute')
     ) {
+      if (
+        !this._userHasCleared &&
+        (this.defaultHour !== null || this.defaultMinute !== null) &&
+        !this.value
+      ) {
+        const date = new Date();
+        if (this.defaultHour !== null) date.setHours(this.defaultHour);
+        if (this.defaultMinute !== null) date.setMinutes(this.defaultMinute);
+        date.setSeconds(0);
+        date.setMilliseconds(0);
+        this.value = date;
+        this.requestUpdate();
+      }
+
       if (this.flatpickrInstance && !this._isClearing) {
         await this.debouncedUpdate();
       }


### PR DESCRIPTION
## Summary 

Default Flatpickr behavior is to hide the current displayed year when minDate and maxDate hav the same year. We are now overriding this for better, less confusing UX.

Additionally, the timing of how flatpickr was getting initialized was not correct when `defaultDate` values were coming from a back-end db. Added some additional logic to each component to account for this timing discrepency.