### PR TITLE
fix(pickers): address db populated max/minDate, defaultDate issues

### DIFF
--- a/src/common/helpers/flatpickr.ts
+++ b/src/common/helpers/flatpickr.ts
@@ -542,6 +542,17 @@ export function setCalendarAttributes(
   const container = instance.calendarContainer;
   if (!container) return;
 
+  const { minDate, maxDate } = instance.config;
+  if (minDate && maxDate) {
+    const minY = new Date(minDate).getFullYear();
+    const maxY = new Date(maxDate).getFullYear();
+    if (minY === maxY) {
+      container.classList.add('single-year');
+    } else {
+      container.classList.remove('single-year');
+    }
+  }
+
   requestAnimationFrame(() => {
     const mode = instance?.config.mode as
       | 'single'

--- a/src/common/scss/shidoka-flatpickr-theme.scss
+++ b/src/common/scss/shidoka-flatpickr-theme.scss
@@ -15,6 +15,13 @@ $weekday: var(--kd-color-date-and-time-picker-text-placeholder);
 $calendar-box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.08),
   0px 1px 2px 0px rgba(0, 0, 0, 0.12);
 
+.flatpickr-calendar.single-year {
+  .flatpickr-current-month .numInputWrapper span.arrowUp,
+  .flatpickr-current-month .numInputWrapper span.arrowDown {
+    visibility: hidden;
+  }
+}
+
 .flatpickr-calendar {
   position: absolute;
   bottom: auto;

--- a/src/components/reusable/datePicker/datepicker.ts
+++ b/src/components/reusable/datePicker/datepicker.ts
@@ -511,57 +511,38 @@ export class DatePicker extends FormMixin(LitElement) {
     }
 
     if (changedProperties.has('value') && !this._isClearing) {
-      let newValue = this.value;
+      const val = this.value;
+      const isNull = val === null || (Array.isArray(val) && val.length === 0);
 
-      if (typeof newValue === 'string') {
-        try {
-          const strValue = newValue as string;
-          if (strValue.trim() !== '' && /\d{4}-\d{2}-\d{2}/.test(strValue)) {
-            const [year, month, day] = strValue.split('-').map(Number);
-            if (!isNaN(year) && !isNaN(month) && !isNaN(day)) {
-              this.value = new Date(year, month - 1, day, 12);
-              newValue = this.value;
-              if (this.flatpickrInstance) {
-                this.flatpickrInstance.setDate(newValue, true);
-              }
-            }
-          }
-        } catch (e) {
-          console.warn('Error parsing date string:', e);
-        }
-      }
-
-      const isNull =
-        newValue === null || (Array.isArray(newValue) && newValue.length === 0);
       if (isNull && this.flatpickrInstance) {
         this._isClearing = true;
         try {
           this.flatpickrInstance.clear();
-          if (this._inputEl) {
-            this._inputEl.value = '';
-          }
+          this._inputEl.value = '';
         } finally {
           this._isClearing = false;
         }
+      } else if (this.flatpickrInstance && val != null) {
+        const dates: Date[] = Array.isArray(val)
+          ? val.filter((d): d is Date => d instanceof Date)
+          : val instanceof Date
+          ? [val]
+          : [];
+
+        if (dates.length > 0) {
+          this.flatpickrInstance.setDate(dates, false);
+        }
       }
+
       this.requestUpdate();
     }
 
     if (changedProperties.has('defaultDate') && !this._isClearing) {
-      if (this.defaultDate && !this.value) {
-        const processedDates = this.processDefaultDates(this.defaultDate);
-        if (processedDates && processedDates.length > 0) {
-          if (this.mode === 'multiple') {
-            this.value = [...processedDates];
-          } else {
-            this.value = processedDates[0];
-          }
-          this.requestUpdate();
-        }
-      }
-
-      if (this.flatpickrInstance) {
-        this.debouncedUpdate();
+      const processedDates = this.processDefaultDates(this.defaultDate);
+      if (processedDates.length > 0 && this.flatpickrInstance) {
+        this.value =
+          this.mode === 'multiple' ? [...processedDates] : processedDates[0];
+        this.flatpickrInstance.setDate(processedDates, true);
       }
     }
 
@@ -571,19 +552,17 @@ export class DatePicker extends FormMixin(LitElement) {
           if (date instanceof Date) return date;
           if (typeof date === 'number') return new Date(date);
           if (typeof date === 'string') {
-            const [year, month, day] = date.split('-').map(Number);
-            if (!isNaN(year) && !isNaN(month) && !isNaN(day)) {
-              return new Date(year, month - 1, day);
-            }
+            const [y, m, d] = date.split('-').map(Number);
+            return !isNaN(y) && !isNaN(m) && !isNaN(d)
+              ? new Date(y, m - 1, d)
+              : date;
           }
           return date;
         });
       } else {
         this._processedDisableDates = [];
       }
-      if (this.flatpickrInstance) {
-        this.debouncedUpdate();
-      }
+      this.flatpickrInstance && this.debouncedUpdate();
     }
 
     if (
@@ -595,11 +574,7 @@ export class DatePicker extends FormMixin(LitElement) {
     ) {
       this._enableTime = updateEnableTime(this.dateFormat);
       if (this.flatpickrInstance && this._initialized && !this._isClearing) {
-        if (changedProperties.has('dateFormat')) {
-          this.debouncedUpdate();
-        } else {
-          this.debouncedUpdate();
-        }
+        this.debouncedUpdate();
       }
     }
 
@@ -608,9 +583,7 @@ export class DatePicker extends FormMixin(LitElement) {
         this.datePickerDisabled) ||
       (changedProperties.has('readonly') && this.readonly)
     ) {
-      if (this.flatpickrInstance) {
-        this.flatpickrInstance.close();
-      }
+      this.flatpickrInstance?.close();
     }
   }
 
@@ -844,15 +817,32 @@ export class DatePicker extends FormMixin(LitElement) {
     return options;
   }
 
-  handleOpen() {
+  async handleOpen() {
     if (this.readonly) {
       this.flatpickrInstance?.close();
       return;
     }
+
     if (!this._shouldFlatpickrOpen) {
       this.flatpickrInstance?.close();
       this._shouldFlatpickrOpen = true;
+      return;
     }
+
+    this.flatpickrInstance?.open();
+    this._shouldFlatpickrOpen = false;
+
+    const cfg = this.flatpickrInstance!.config;
+    if (cfg.minDate && cfg.maxDate) {
+      const minY = new Date(cfg.minDate as any).getFullYear();
+      const maxY = new Date(cfg.maxDate as any).getFullYear();
+      this.flatpickrInstance!.calendarContainer.classList.toggle(
+        'single-year',
+        minY === maxY
+      );
+    }
+
+    hideEmptyYear();
   }
 
   async handleClose() {
@@ -1038,6 +1028,15 @@ export class DatePicker extends FormMixin(LitElement) {
       this.flatpickrInstance.clear();
     }
     this._hasInteracted = false;
+  }
+
+  public getValue(): Date | Date[] | null {
+    return this.value;
+  }
+
+  public setValue(newValue: Date | Date[] | null): void {
+    this.value = newValue;
+    this.requestUpdate();
   }
 }
 

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -1378,6 +1378,15 @@ export class DateRangePicker extends FormMixin(LitElement) {
     this._hasInteracted = false;
     this._validate(false, false);
   }
+
+  public getValue(): [Date | null, Date | null] {
+    return this.value;
+  }
+
+  public setValue(newValue: [Date | null, Date | null]): void {
+    this.value = newValue;
+    this.requestUpdate();
+  }
 }
 
 declare global {

--- a/src/components/reusable/timepicker/timepicker.ts
+++ b/src/components/reusable/timepicker/timepicker.ts
@@ -816,6 +816,15 @@ export class TimePicker extends FormMixin(LitElement) {
       this.flatpickrInstance = undefined;
     }
   }
+
+  public getValue(): Date | null {
+    return this.value;
+  }
+
+  public setValue(newValue: Date | null): void {
+    this.value = newValue;
+    this.requestUpdate();
+  }
 }
 
 declare global {


### PR DESCRIPTION
## Summary

### 1. __Dynamic Data Display Problem__

- __Issue__: When developers set `defaultDate` to a string value (e.g., '2024-07-02') from backend databases, the date wasn't showing in the date input field
- __Root Cause__: Components weren't properly handling dynamic data that arrives after component initialization
- __Impact__: Affected DatePicker, DateRangePicker, and TimePicker components

### 2. __Timing Issues with Backend Data__

- __Issue__: Components needed to handle scenarios where default values are set dynamically from API calls or database queries
- __Root Cause__: The components were only processing default values during initial setup, not when they changed later
- __Impact__: Poor user experience when working with dynamic data sources

### 3. __Year input hidden__  

- Our CSS hides the up/down arrows when .single-year is present but we weren’t toggling that class on open (or re-invoking hideEmptyYear()), so the arrow buttons—and sometimes the year input—remained hidden; adding the class toggle based on minDate/maxDate and calling hideEmptyYear() ensures the year spinner stays visible when it should.

## Solutions Implemented:

### 1. __Enhanced Dynamic Data Handling__

- Modified all three components (DatePicker, DateRangePicker, TimePicker) to process default values immediately when they change
- Added logic to handle value updates even when Flatpickr isn't ready yet
- Improved timing resilience for dynamic data loading scenarios

### 2. __Improved Component Lifecycle Management__

- Enhanced the `updated()` lifecycle method to properly handle `defaultDate` changes
- Added proper form value updates and component re-rendering when dynamic data arrives
- Ensured compatibility with different component modes and configurations


