### PR TITLE
fix(DatePicker): invalid preselected Date

### DIFF
--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -1171,6 +1171,8 @@ export class DateRangePicker extends FormMixin(LitElement) {
         }
       }
     } catch (e) {
+      this.invalidText = this._textStrings.pleaseSelectValidDate;
+      this.defaultDate = null;
       console.error('Error in setInitialDates:', (e as Error).message);
     }
   }


### PR DESCRIPTION
## Summary

 Invalid preselected default date when min and max date provided - Will set the input field empty + show invalid text

## ADO Story or GitHub Issue Link

Link here (if applicable).



## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## Screenshots

(if any)
