### PR TITLE
fix(skeleton): cleanup lines prop/styles and usage docs

### DIFF
--- a/src/components/reusable/loaders/skeleton.scss
+++ b/src/components/reusable/loaders/skeleton.scss
@@ -20,21 +20,20 @@
 :host {
   display: block;
   width: 100%;
-  height: auto;
 }
 
-:host(.skeleton-item) {
-  margin-bottom: 16px;
-}
-
-:host(.last-item) {
-  margin-bottom: 0;
-  margin-right: 0;
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 :host([inline]) {
   display: inline-block;
-  width: 100%;
+
+  & .container {
+    flex-direction: row;
+  }
 }
 
 .skeleton {
@@ -48,6 +47,7 @@
 
   &.ai-Skeleton {
     background: var(--kd-color-background-gradients-ai-loader-start-gradient);
+
     &::after {
       background: linear-gradient(
         90deg,

--- a/src/components/reusable/loaders/skeleton.stories.js
+++ b/src/components/reusable/loaders/skeleton.stories.js
@@ -29,39 +29,17 @@ export default {
 };
 
 const Template = (args) => {
-  const skeletons = Array(args.lines)
-    .fill(null)
-    .map((_, index) => {
-      const isLast = index === args.lines - 1;
-      return html`
-        <div
-          style="${args.inline
-            ? `flex: 1; margin-right: ${isLast ? '0' : '8px'};`
-            : ''}"
-        >
-          <kyn-skeleton
-            class="${args.inline ? 'inline' : 'skeleton-item'} ${isLast
-              ? 'last-item'
-              : ''}"
-            shape=${args.shape}
-            size=${args.size || ''}
-            ?inline=${args.inline}
-            width=${args.width || ''}
-            height=${args.height || ''}
-            ?aiConnected=${args.aiConnected}
-          ></kyn-skeleton>
-        </div>
-      `;
-    });
-
   return html`
-    <div
-      style="${args.inline
-        ? 'display: flex; width: 100%; flex-wrap: wrap; gap: 8px;'
-        : ''}"
-    >
-      ${skeletons}
-    </div>
+    <kyn-skeleton
+      class="${args.inline ? 'inline' : 'skeleton-item'}"
+      shape=${args.shape}
+      size=${args.size || ''}
+      lines=${args.lines}
+      ?inline=${args.inline}
+      width=${args.width || ''}
+      height=${args.height || ''}
+      ?aiConnected=${args.aiConnected}
+    ></kyn-skeleton>
   `;
 };
 

--- a/src/components/reusable/loaders/skeleton.ts
+++ b/src/components/reusable/loaders/skeleton.ts
@@ -75,7 +75,7 @@ export class Skeleton extends LitElement {
       `
     );
 
-    return html` ${skeletonLines} `;
+    return html` <div class="container">${skeletonLines}</div> `;
   }
 }
 


### PR DESCRIPTION
## Summary

- A loop internally for the `lines` prop was conflicting with a loop in the story, making things confusing.
- Cleaned up the story template.
- Cleaned up the component template and styles.