### PR TITLE
fix(enhanced dropdown): requested features, and token updates

### DIFF
--- a/src/components/reusable/dropdown/enhancedDropdown.stories.js
+++ b/src/components/reusable/dropdown/enhancedDropdown.stories.js
@@ -11,7 +11,7 @@ import businessConsultIcon from '@kyndryl-design-system/shidoka-icons/svg/monoch
 import aiOpsIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/AIOps-docs.svg';
 import boxIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/box.svg';
 import branchIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/branch.svg';
-import downIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/20/chevron-down.svg';
+import downIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/chevron-down.svg';
 
 export default {
   title: 'Components/Dropdown/Enhanced Dropdown',
@@ -271,6 +271,7 @@ export const ButtonAnchor = {
           kind="secondary-ai"
           size="small"
           iconPosition="right"
+          style="margin-top: 8px;"
         >
           ${args.buttonText || args.placeholder || 'Select option'}
           <span slot="icon">${unsafeSVG(downIcon)}</span>

--- a/src/components/reusable/dropdown/enhancedDropdownOption.ts
+++ b/src/components/reusable/dropdown/enhancedDropdownOption.ts
@@ -129,7 +129,11 @@ export class EnhancedDropdownOption extends LitElement {
           <div class="text-content">
             <div class="title-content">
               <slot name="title" @slotchange=${this.onTitleSlotChange}></slot>
-              <span class="tag-container"><slot name="tag"></slot></span>
+              ${!this.selected
+                ? html`<span class="tag-container"
+                    ><slot name="tag"></slot
+                  ></span>`
+                : null}
             </div>
             <div class="description-container">
               <slot name="description"></slot>


### PR DESCRIPTION
## Summary

Primary purpose of this PR is to update the color tokens to reflect recent, extensive changes to the Figma file for all menu items from the UX team.

Secondarily:

1. kyn-tag should not be visible when an enhanced option is selected
2. clean up button variant spacing to be more aligned to component spacing elsewhere in Shidoka
3. reduce size of chevron in Enhanced dropdown option button anchor variant.

## Figma Link

[Dropdown Component Figma](https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library?node-id=4162-192498&p=f&m=dev)

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots

(when available)
