### PR TITLE
fix(notification): corrected click event detail structure

### DIFF
--- a/src/components/reusable/notification/notification.ts
+++ b/src/components/reusable/notification/notification.ts
@@ -306,7 +306,7 @@ export class Notification extends LitElement {
 
   private _handleCardClick(e: any) {
     const event = new CustomEvent('on-notification-click', {
-      detail: e.detail.origEvent,
+      detail: { origEvent: e.detail.origEvent },
     });
     this.dispatchEvent(event);
   }


### PR DESCRIPTION
## Summary

`on-card-click` origEvent details were not being cascaded up through `on-notification-click` even details the same as in the documented structure.