### PR TITLE
fix(pageTitle): subtitle font-family and size to match figma

### DIFF
--- a/src/components/reusable/pagetitle/pageTitle.scss
+++ b/src/components/reusable/pagetitle/pageTitle.scss
@@ -51,7 +51,7 @@
   }
 
   &-subtitle {
-    @include typography.type-ui-02;
+    @include typography.type-body-02;
     color: var(--kd-color-text-level-secondary);
     margin-top: 2px;
     margin-bottom: 0;


### PR DESCRIPTION
## Summary

Dev alerted team in General chat that the Page Title component `subtitle` was set to 14px, when it should be set to 16px per Figma design.

Modified scss to change typography @interface from `type-ui-02` to `type-body-02`. Now subtitle is `'Roboto'` `16px`.

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Testing Instructions

Provide guidance to reviewers/testers here.

## Screenshots

#### Figma
<img width="786" height="441" alt="Screenshot 2025-08-20 at 12 12 41 PM" src="https://github.com/user-attachments/assets/e3df2020-8843-4825-9ac5-5a28350acf89" />

#### Previous
<img width="1385" height="685" alt="Screenshot 2025-08-20 at 12 10 12 PM" src="https://github.com/user-attachments/assets/0e1d1603-cdb2-4788-bd08-2ef8a35d265b" />


#### Updated
<img width="1640" height="524" alt="Screenshot 2025-08-20 at 12 14 13 PM" src="https://github.com/user-attachments/assets/ef792bba-16eb-421e-ad3d-6f545c4ef68c" />

