### PR TITLE
fix(dropdown): additional fixes for icon color, focus state outline, default pagination state border

### DIFF
--- a/src/common/scss/menu-item.scss
+++ b/src/common/scss/menu-item.scss
@@ -12,6 +12,10 @@
   .menu-item-inner-el {
     color: var(--kd-color-text-level-primary);
     transition: color 150ms ease-out;
+
+    &.check-icon {
+      color: var(--kd-color-icon-primary);
+    }
   }
 
   transition: background-color 150ms ease-out, color 150ms ease-out;

--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -8,6 +8,14 @@
   display: inline-block;
 }
 
+:host(.pagination-dropdown) .select[aria-controls='options'] {
+  border: 1px solid transparent;
+}
+
+:host(.pagination-dropdown) .select {
+  border: 1px solid transparent;
+}
+
 .wrapper {
   position: relative;
 }

--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -8,10 +8,6 @@
   display: inline-block;
 }
 
-:host(.pagination-dropdown) .select[aria-controls='options'] {
-  border: 1px solid transparent;
-}
-
 :host(.pagination-dropdown) .select {
   border: 1px solid transparent;
 }

--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -71,15 +71,12 @@ slot[name='icon']::slotted(*) {
 
 /* Default focus */
 .select:focus-within {
-  outline: 1px solid var(--kd-color-border-variants-focus);
+  outline: 2px solid var(--kd-color-border-variants-focus);
   outline-offset: 0;
-  border-color: var(--kd-color-border-variants-focus);
-}
 
-.select:focus-within {
-  outline: 1px solid var(--kd-color-border-variants-focus);
-  outline-offset: 0;
-  border-color: var(--kd-color-border-variants-focus);
+  &:hover {
+    border-color: transparent;
+  }
 }
 
 .arrow-icon {

--- a/src/components/reusable/dropdown/dropdownOption.scss
+++ b/src/components/reusable/dropdown/dropdownOption.scss
@@ -7,7 +7,7 @@
 
 .option {
   cursor: default;
-  padding: 8px 16px;
+  padding: 16px;
   height: 48px;
   transition: background-color 150ms ease-out;
   display: flex;
@@ -34,6 +34,7 @@
 
   slot[name='icon']::slotted(span) {
     display: flex;
+    padding: 0.5rem 0.5rem 0.5rem 0;
   }
 }
 

--- a/src/components/reusable/dropdown/dropdownOption.ts
+++ b/src/components/reusable/dropdown/dropdownOption.ts
@@ -74,6 +74,12 @@ export class DropdownOption extends LitElement {
   @state()
   accessor kind: 'ai' | 'default' = 'default';
 
+  /** slotted icon added state.
+   * @ignore
+   */
+  @state()
+  accessor hasIcon = false;
+
   @property({ type: String, reflect: true })
   override accessor role = 'option';
 
@@ -124,9 +130,21 @@ export class DropdownOption extends LitElement {
               `}
         </span>
 
-        <span class="menu-item-inner-el icon"
-          ><slot name="icon" style="display:flex"></slot
-        ></span>
+        ${this.hasIcon
+          ? html`<span class="menu-item-inner-el icon"
+              ><slot
+                name="icon"
+                style="display:flex"
+                @slotchange=${(e: any) => this.handleIconSlotChange(e)}
+              ></slot
+            ></span>`
+          : html`
+              <slot
+                name="icon"
+                style="display:none"
+                @slotchange=${(e: any) => this.handleIconSlotChange(e)}
+              ></slot>
+            `}
         ${this.selected && !this.multiple
           ? html`
               <span class="menu-item-inner-el check-icon"
@@ -234,6 +252,11 @@ export class DropdownOption extends LitElement {
       },
     });
     this.dispatchEvent(event);
+  }
+
+  private handleIconSlotChange(e: any) {
+    const nodes = e.target.assignedNodes({ flatten: true });
+    this.hasIcon = nodes.length > 0;
   }
 }
 

--- a/src/components/reusable/pagination/pagination-navigation-buttons.ts
+++ b/src/components/reusable/pagination/pagination-navigation-buttons.ts
@@ -105,6 +105,7 @@ export class PaginationNavigationButtons extends LitElement {
       <span class="page-range" role="status" aria-live="polite">
         <kyn-dropdown
           name="page-number"
+          class="pagination-dropdown"
           label="${this.pageNumberLabel}"
           ?hideLabel=${true}
           inline

--- a/src/components/reusable/pagination/pagination-page-size-dropdown.ts
+++ b/src/components/reusable/pagination/pagination-page-size-dropdown.ts
@@ -62,6 +62,7 @@ export class PaginationPageSizeDropdown extends LitElement {
       <label> ${this.textStrings.itemsPerPage} </label>
       <kyn-dropdown
         name="page-size"
+        class="pagination-dropdown"
         label="${this.pageSizeDropdownLabel}"
         inline
         size="sm"


### PR DESCRIPTION
## Summary

Additional fixes with pagination-specific dropdown:

- [ ] pagination dropdown was inheriting the dropdown input default border -- using a `.pagination-dropdown` class identifier to target these dropdowns and remove the border in default state
- [ ] non-enhanced menu-item color token correction
- [ ] dropdown outline/border width and color tokens correction in focus state 
- [ ] clean up styles to use px instead of rem

## ADO Story or GitHub Issue Link

#569 
