### PR TITLE
fix: handleClick so that dev can prevent reload

### DIFF
--- a/src/components/reusable/card/card.ts
+++ b/src/components/reusable/card/card.ts
@@ -79,14 +79,14 @@ export class Card extends LitElement {
   }
 
   private handleClick(e: Event) {
-    const custom = new CustomEvent('on-card-click', {
+    const event = new CustomEvent('on-card-click', {
       detail: { origEvent: e },
       bubbles: true,
       composed: true,
       cancelable: true,
     });
-    const dispatchResult = this.dispatchEvent(custom);
-    if (!dispatchResult || custom.defaultPrevented) {
+    const dispatchResult = this.dispatchEvent(event);
+    if (!dispatchResult || event.defaultPrevented) {
       e.preventDefault();
     }
   }


### PR DESCRIPTION
## Summary

Dev consumer reports:

> I am trying to use the card clickable component to open a drawer the idea is to have it as a floating button, I am trying to pass the function that opens the drawer with a prevent default to avoid the loading of the page, but is still happening when click is just reloading the page. 
 
> Is possible to use the card with the same functionality as a button, is because of the style that the designer wants to use the card.

#### Change

- card now dispatches a cancelable, bubbling, composed CustomEvent('on-card-click') from inside the anchor click handler
- after dispatching, the component checks whether the custom event was prevented (custom.defaultPrevented) and, if so, calls preventDefault() on the original click event to stop native navigation.

