### PR TITLE
fix(blockCodeView): only show copy button on hover

### DIFF
--- a/src/components/reusable/blockCodeView/blockCodeView.scss
+++ b/src/components/reusable/blockCodeView/blockCodeView.scss
@@ -191,8 +191,8 @@ pre.line-numbers {
       overflow: -moz-scrollbars-vertical;
 
       .code-view__copy-button {
-        top: 16px;
-        right: 16px;
+        top: 8px;
+        right: 8px;
       }
 
       .code-snippet-wrapper {
@@ -240,6 +240,40 @@ pre.line-numbers {
       transform: rotate(180deg);
     }
   }
+}
+
+// ONLY SHOW COPY BUTTON ON :hover
+
+.code-view__container:hover .code-view__copy-button {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.code-view__copy-button {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.4s ease-in-out, visibility 0.4s ease-in-out;
+}
+
+.code-view__copy-button .copy-text {
+  opacity: 0;
+  visibility: visible;
+  display: inline-block;
+  white-space: nowrap;
+  transform: scaleX(1);
+  margin-left: 6px;
+  transition: opacity 0.4s ease-in-out;
+}
+
+.code-view__container:hover .code-view__copy-button .copy-text {
+  opacity: 1;
+}
+
+.code-view__copy-button.icon-only {
+  width: auto;
+  min-width: 0;
 }
 
 // PREPENDED NON-COPYABLE COMMANDLINE SYMBOLS


### PR DESCRIPTION
## Summary

Member of external UX team stated that the copy button was blocking long lines of code in the blockCodeView element. During Shidoka Office Hours, consensus was to add a simple hover effect to the Copy button.

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file
