### PR TITLE
fix: copy button persists on hover off only when copy-active

### DIFF
--- a/src/components/reusable/blockCodeView/blockCodeView.scss
+++ b/src/components/reusable/blockCodeView/blockCodeView.scss
@@ -250,6 +250,13 @@ pre.line-numbers {
   pointer-events: auto;
 }
 
+/* also show copy when copy action is active (persist while copied) */
+.code-view__container.copy-active .code-view__copy-button {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
 .code-view__copy-button {
   opacity: 0;
   visibility: hidden;
@@ -268,6 +275,11 @@ pre.line-numbers {
 }
 
 .code-view__container:hover .code-view__copy-button .copy-text {
+  opacity: 1;
+}
+
+/* ensure copy text also shows when copy action is active */
+.code-view__container.copy-active .code-view__copy-button .copy-text {
   opacity: 1;
 }
 

--- a/src/components/reusable/blockCodeView/blockCodeView.ts
+++ b/src/components/reusable/blockCodeView/blockCodeView.ts
@@ -223,6 +223,7 @@ export class BlockCodeView extends LitElement {
       'shidoka-syntax-theme--light': this.darkTheme === 'light',
       'expanded-code-view': this.codeExpanded,
       'has-overflow': this.hasOverflow,
+      'copy-active': this._copyState?.copied,
     });
   }
 


### PR DESCRIPTION
## Summary

When copy button is pressed, make a 'copy-active' to interrupt normal hover behavior and have the 'Copied!' message persist for the duration of the existing setTimeout.