### PR TITLE
fix(dropdown): pagination dropdown on windows w scrollbar

### DIFF
--- a/src/common/scss/menu-item.scss
+++ b/src/common/scss/menu-item.scss
@@ -8,6 +8,7 @@
 
 .menu-item {
   background-color: var(--kd-color-background-menu-state-default);
+  transition: background-color 150ms ease-out;
 
   .menu-item-inner-el {
     color: var(--kd-color-text-level-primary);
@@ -18,13 +19,15 @@
     }
   }
 
-  transition: background-color 150ms ease-out, color 150ms ease-out;
-
   &:hover:not([disabled]) {
     background-color: var(--kd-color-background-menu-state-hover);
 
     .menu-item-inner-el {
       color: var(--kd-color-text-level-light);
+    }
+
+    slot[name='icon']::slotted(span) {
+      color: var(--kd-color-icon-light);
     }
   }
 
@@ -33,14 +36,6 @@
 
     .menu-item-inner-el {
       color: var(--kd-color-text-level-primary);
-    }
-  }
-
-  &:active:not([disabled]) {
-    background-color: var(--kd-color-background-menu-state-pressed);
-
-    .menu-item-inner-el {
-      color: var(--kd-color-text-level-light);
     }
   }
 
@@ -160,8 +155,7 @@
     &[highlighted]:not([disabled]) {
       background-color: var(--kd-color-background-menu-state-ai-open);
 
-      &:hover,
-      &[highlighted] {
+      &:hover {
         background-color: var(--kd-color-background-menu-state-ai-hover);
 
         .menu-item-inner-el {

--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -38,6 +38,7 @@ slot[name='icon']::slotted(*) {
   border: 1px solid var(--kd-color-border-forms-default);
   border-radius: 4px;
   height: 48px;
+  min-width: 95px;
   padding: 0 48px 0 16px;
   cursor: pointer;
   font-weight: var(--kd-font-weight-regular);


### PR DESCRIPTION
## Summary

Icon token on hover was not being applied

On Windows machines (Edge tested), dropdown scrollbar is persistent, so it is still obscuring the dropdown option content.

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots

### Issue 1
#### Before 
<img width="395" height="325" alt="Screenshot 2025-08-29 at 9 02 59 AM" src="https://github.com/user-attachments/assets/eccb699b-602d-4a0b-a029-7fdb7033985e" />

#### Fixed
<img width="319" height="387" alt="Screenshot 2025-08-29 at 9 02 48 AM" src="https://github.com/user-attachments/assets/77fe65dd-9c34-4808-81cb-3064215ab52d" />

### Issue 2
#### Before (Windows only)
<img width="809" height="361" alt="Screenshot 2025-08-29 at 9 00 56 AM" src="https://github.com/user-attachments/assets/ea5f21fe-10b2-41d2-9f6b-e66fa4401a40" />

#### Fixed
<img width="858" height="443" alt="Screenshot 2025-08-29 at 8 59 50 AM" src="https://github.com/user-attachments/assets/4fba9bb8-486d-4633-9f78-1bdff95ba15c" />
