### PR TITLE
fix(dropdown): multiselect clear icon visibility fix

### DIFF
--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -177,8 +177,9 @@ slot[name='icon']::slotted(*) {
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
+  gap: 2px;
   border: none;
-  width: 48px;
+  min-width: 24px;
   height: 24px;
   padding: 8px;
   border-radius: 4px;

--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -178,7 +178,7 @@ slot[name='icon']::slotted(*) {
   align-items: center;
   justify-content: space-between;
   border: none;
-  width: 24px;
+  width: 48px;
   height: 24px;
   padding: 8px;
   border-radius: 4px;


### PR DESCRIPTION
## Summary

Dropdown - Multiselect : `X` clear icon not visible on selected item 

## GitHub Issue Link

[Link](https://github.com/kyndryl-design-system/shidoka-applications/issues/579)

## Figma Link

NA


## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [x] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## Screenshots

## Before 

<img width="790" height="380" alt="image" src="https://github.com/user-attachments/assets/b7c0b221-a67e-431c-b8ae-6973ec29e12b" />


## After

<img width="783" height="476" alt="image" src="https://github.com/user-attachments/assets/d09f7462-0faa-4472-a916-a769466c4c2f" />
