### PR TITLE
fix(tabs): contain z-index context to prevent border appearing behind parent elements

### DIFF
--- a/src/components/reusable/tabs/tabs.scss
+++ b/src/components/reusable/tabs/tabs.scss
@@ -27,6 +27,7 @@
   gap: 4px;
   overflow-x: auto;
   position: relative;
+  z-index: 0;
 
   &::after {
     content: '';


### PR DESCRIPTION
## Summary

Tabs border could disappear behind parent elements if they had a background color.

## GitHub Issue Link

resolves #603 

## Testing Instructions

Add a background color to any parent element of `kyn-tabs`, observe the underline doesn't disappear.