### PR TITLE
fix(tabs): vertical, ai-connected hover text color

### DIFF
--- a/src/components/reusable/tabs/tab.scss
+++ b/src/components/reusable/tabs/tab.scss
@@ -89,6 +89,10 @@
 @media (min-width: breakpoints.$bp-md) {
   :host([vertical]) {
     border-radius: 0 4px 4px 0;
+
+    &::after {
+      border-radius: 0 4px 4px 0;
+    }
   }
 }
 

--- a/src/components/reusable/tabs/tab.scss
+++ b/src/components/reusable/tabs/tab.scss
@@ -105,7 +105,7 @@
       z-index: 0;
       background: var(--kd-color-background-button-primary-ai-hover);
       border-color: var(--kd-color-border-button-secondary-ai-hover);
-      color: var(--kd-color-text-level-light);
+      color: var(--kd-color-text-level-primary);
     }
   }
 }


### PR DESCRIPTION
## Summary 

- quick token correction on vertical, ai-connected Tabs in hover state.

- target `::after` properly to set border-radius on vertical ai tabs