### PR TITLE
fix(Modal): ai background gradient fix

### DIFF
--- a/src/common/scss/gradients.scss
+++ b/src/common/scss/gradients.scss
@@ -85,7 +85,7 @@ $ai-gradient-default: var(
 }
 
 /// Gradient Backgrounds for AI-connected components
-:root {
+:host {
   --ai-radial-strength: 20%;
   --ai-radial-outer: 75%;
   --ai-right-strength: 15%;

--- a/src/components/reusable/sideDrawer/sideDrawer.scss
+++ b/src/components/reusable/sideDrawer/sideDrawer.scss
@@ -215,33 +215,5 @@ form {
 dialog.ai-connected {
   @include elevation.shadow(3, true);
   background: var(--kd-color-background-container-ai-default);
-
-  &.gradient-bkg {
-    background-color: var(--kd-color-background-container-ai-default);
-
-    background-image: radial-gradient(
-        circle at 0% 0%,
-        color-mix(
-            in oklab,
-            var(--kd-color-border-ai-default-gradient-start) 20%,
-            transparent
-          )
-          0%,
-        transparent 35%
-      ),
-      radial-gradient(
-        circle at 100% 50%,
-        color-mix(
-            in oklab,
-            var(--kd-color-border-ai-default-gradient-end) 15%,
-            transparent
-          )
-          0%,
-        transparent 55%
-      );
-
-    background-repeat: no-repeat, no-repeat;
-    background-position: 0 0, 100% 50%;
-    background-size: cover, cover;
-  }
+  @extend .gradient-bkg;
 }


### PR DESCRIPTION
## Summary

AI Modal : gradient background not getting applied due to some undefined root token 

https://shidoka-applications.netlify.app/?path=/story/components-modal--ai-connected&globals=theme:light

<img width="1382" height="571" alt="Screenshot 2025-10-08 at 4 49 49 PM" src="https://github.com/user-attachments/assets/6f93f236-248a-4436-8e54-f3cc89d80872" />



## ADO Story or GitHub Issue Link

Link here (if applicable).

## Figma Link

Link here (if applicable).


## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## Screenshots


