### PR TITLE
fix(dropdown): disabled On hover visibility icon |AI menu icon fix | selected menu text fix

### DIFF
--- a/src/common/scss/menu-item.scss
+++ b/src/common/scss/menu-item.scss
@@ -25,6 +25,10 @@
     color: var(--kd-color-text-level-disabled);
   }
 
+  &[selected] .menu-item-inner-el {
+    color: var(--kd-color-text-level-disabled);
+  }
+
   &,
   & * {
     cursor: not-allowed;
@@ -35,6 +39,10 @@
 
     .menu-item-inner-el {
       color: var(--kd-color-text-level-disabled);
+    }
+
+    slot[name='icon']::slotted(span) {
+      color: var(--kd-color-icon-disabled);
     }
   }
 }


### PR DESCRIPTION
## Summary

Light Mode - Disabled state- Menu items
1.Default - On hover visibility icon Fix
2. AI - On hover visibility icon Fix
3. MultiSelect : Selected : Menu text fix



https://github.com/user-attachments/assets/f0b921f1-d4ee-4191-9229-b4a2bf26257a



## GitHub Issue Link

[AB#2568087](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2568087)

https://github.com/kyndryl-design-system/shidoka-applications/issues/612

## Figma Link

NA

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screen Rec.

https://github.com/user-attachments/assets/8c92698e-f065-4b8e-8b6d-e0eb7201f019



