### PR TITLE
fix: header title should not be clickable, per ux

### DIFF
--- a/src/components/global/header/header.scss
+++ b/src/components/global/header/header.scss
@@ -69,7 +69,7 @@
   font-weight: var(--kd-font-weight-light);
   display: none;
   margin-top: -2px;
-  margin-left: 16px;
+  margin-left: 0;
   padding-left: 16px;
   border-left: 1px solid var(--kd-color-border-level-tertiary);
 

--- a/src/components/global/header/header.ts
+++ b/src/components/global/header/header.ts
@@ -80,9 +80,9 @@ export class Header extends LitElement {
           <slot name="logo" @slotchange=${this.handleSlotChange}>
             ${unsafeHTML(logo)}
           </slot>
-
-          <span class="title">${this.appTitle}</span>
         </a>
+
+        <span class="title">${this.appTitle}</span>
 
         <slot name="center"></slot>
 


### PR DESCRIPTION
## Summary

> Right now if you click the logo or the title they take you to the homepage (console), only the logo should do that. DEVs say they cannot do this as the Shidoka component they have to work with has the title as clickable.

![e86a28dd-389b-45a6-b171-ad9e9437614a](https://github.com/user-attachments/assets/8ddad99f-e406-4081-a737-bb74ca7f3015)

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file