### PR TITLE
fix(dropdown): inline prop style fix

### DIFF
--- a/src/components/reusable/dropdown/dropdown.scss
+++ b/src/components/reusable/dropdown/dropdown.scss
@@ -100,6 +100,11 @@ slot[name='icon']::slotted(*) {
     padding-right: 80px;
   }
 
+  &.inline {
+    border-color: transparent;
+    background-color: transparent;
+  }
+
   &.ai-connected:not([disabled], [readonly], .is-readonly) {
     border: 1px solid transparent;
     background: var(--kd-color-background-menu-state-ai-default);


### PR DESCRIPTION
## Summary

Issue : Enable inline prop , doesn't hide the border of the dropdown.


## ADO Story or GitHub Issue Link

resolves https://github.com/kyndryl-design-system/shidoka-applications/issues/625

## Figma Link

[Figma](https://www.figma.com/design/93GXasEpCSXeHjcKNV8LlW/2.3-Coco?node-id=4-59029&m=dev)


## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file



## Screenshots

(if any)
