### PR TITLE
fix(datepickers): docs typo corrected

### DIFF
--- a/src/components/reusable/datePicker/datepicker.ts
+++ b/src/components/reusable/datePicker/datepicker.ts
@@ -52,7 +52,7 @@ const _defaultTextStrings = {
 
 /**
  * Datepicker: uses Flatpickr's datetime picker library -- `https://flatpickr.js.org`
- * @fires on-change - Captures the input event and emits the selected value and original event details. `detail:{ dataString: string, dates: date, source: string }`
+ * @fires on-change - Captures the input event and emits the selected value and original event details. `detail:{ dateString: string, dates: date, source: string }`
  * @slot tooltip - Slot for tooltip.
  * @attr {string} [name=''] - The name of the input, used for form submission.
  * @attr {string} [invalidText=''] - The custom validation message when the input is invalid.

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -58,7 +58,7 @@ const _defaultTextStrings = {
 
 /**
  * Date Range Picker: uses Flatpickr library, range picker implementation -- `https://flatpickr.js.org/examples/#range-calendar`
- * @fires on-change - Captures the input event and emits the selected value and original event details. `detail:{ dataString: string,dates:[],source:string}`
+ * @fires on-change - Captures the input event and emits the selected value and original event details. `detail:{ dateString: string,dates:[],source:string}`
  * @slot tooltip - Slot for tooltip.
  * @attr {string} [name=''] - The name of the input, used for form submission.
  * @attr {string} [invalidText=''] - The custom validation message when the input is invalid.


### PR DESCRIPTION
## Summary

Typo in JSDoc for datpicker.ts and daterangepicker.ts -- `dataString` should be `dateString`