### PR TITLE
fix(table-toolbar): discrepencies in typography and line-height

### DIFF
--- a/src/components/reusable/table/table-toolbar.scss
+++ b/src/components/reusable/table/table-toolbar.scss
@@ -18,9 +18,11 @@
   font-size: 20px;
   font-weight: var(--kd-font-weight-medium);
   color: var(--kd-color-text-level-primary);
+  line-height: 24px;
 }
 
 .subtitle {
+  @include typography.type-body-02;
   color: var(--kd-color-text-level-secondary);
 }
 


### PR DESCRIPTION
## Summary

Continued discrepancies between figma for data table title and subtitle -- fully reconciled now.

```
.title {
  // token will be created for 20px Roboto
  font-size: 20px;
  font-weight: var(--kd-font-weight-medium);
  color: var(--kd-color-text-level-primary);
  line-height: 24px;
}

.subtitle {
  @include typography.type-body-02;
  color: var(--kd-color-text-level-secondary);
}
```
<img width="1393" height="672" alt="Screenshot 2025-10-21 at 1 55 10 PM" src="https://github.com/user-attachments/assets/6fa31aca-2369-4d68-8d8f-8f98fb9b3757" />

<img width="1209" height="480" alt="Screenshot 2025-10-21 at 1 55 18 PM" src="https://github.com/user-attachments/assets/5c64557e-fd63-4f7e-8f4e-6b72c796c894" />