### PR TITLE
fix(datatable): on click highlight row fix for touch device On chrome

### DIFF
--- a/src/components/reusable/table/table-row.scss
+++ b/src/components/reusable/table/table-row.scss
@@ -7,13 +7,27 @@
   background-color: var(--kd-color-background-table-row);
 }
 
-:host(:hover) {
-  background-color: var(--kd-color-background-table-row-active) !important;
-  transition: background-color 200ms ease-out;
+@media (hover: hover) and (pointer: fine) {
+  :host(:hover) {
+    background-color: var(--kd-color-background-table-row-active) !important;
+    transition: background-color 200ms ease-out;
+  }
+
+  :host([checkboxselection]:hover:not([disabled])) {
+    background-color: var(--kd-color-background-table-row-active) !important;
+  }
 }
 
-:host([selected]:not([disabled]):not([preventHighlight])),
-:host([checkboxselection]:hover:not([disabled])) {
+/* For touch devices */
+@media (hover: none) and (pointer: coarse) {
+  :host(:active) {
+    background-color: transparent !important;
+    transition: none !important;
+  }
+}
+
+/* Selected state for all devices */
+:host([selected]:not([disabled]):not([preventHighlight])) {
   background-color: var(--kd-color-background-table-row-active) !important;
 }
 


### PR DESCRIPTION
## Summary

Chrome - Touch device : clicking a row adds a background highlight

## GitHub Issue Link

[AB#2600455](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2600455)

https://github.com/kyndryl-design-system/shidoka-applications/issues/636

## Checklist

- [X] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## ScreenRecording

**Before FIX** 


https://github.com/user-attachments/assets/f3e86298-238c-4f32-af47-71c87f5ec990




**After Fix**


https://github.com/user-attachments/assets/2a3fdd83-bcaa-441d-9f29-07e5ff3ad4f3


