### PR TITLE
fix(split button): align with figma

### DIFF
--- a/src/components/reusable/splitButton/splitButton.scss
+++ b/src/components/reusable/splitButton/splitButton.scss
@@ -37,6 +37,9 @@
 
   &-margin-overlapped {
     margin-left: -3px;
+    &.select {
+      border-left: 1px solid transparent !important;
+    }
   }
 
   &--small {

--- a/src/components/reusable/splitButton/splitButton.ts
+++ b/src/components/reusable/splitButton/splitButton.ts
@@ -124,6 +124,8 @@ export class SplitButton extends LitElement {
       'kyn-split-btn--small': this.size === SPLIT_BTN_SIZES.SMALL,
       'kyn-split-btn--medium': this.size === SPLIT_BTN_SIZES.MEDIUM,
       [`kyn-split-btn--icon-${this.iconPosition}`]: !!this.iconPosition,
+      'kyn-split-btn-margin-overlapped':
+        this.kind === SPLIT_BTN_KINDS.SECONDARY && this.destructive,
     };
 
     return html`


### PR DESCRIPTION
## Summary

Secondary Split Button color tokens had fallen out of alignment with Figma design.

## ADO Story or GitHub Issue Link

[AB#2607762](https://dev.azure.com/Kyndryl/f7f7ab25-06ec-43dc-902d-dee2e157cebd/_workitems/edit/2607762)

[Original Ticket](https://dev.azure.com/Kyndryl/Bridge/_workitems/edit/2596655)

## Figma Link

[Link](https://www.figma.com/design/qyPEUQckxj8LUgesi1OEES/Component-Library?m=auto&node-id=21003-166369&t=Nq6iYjTFj1s1A1RW-1)

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots
<img width="253" height="118" alt="Screenshot 2025-11-04 at 7 01 45 AM" src="https://github.com/user-attachments/assets/c496e33e-4de6-4636-b87e-67ea948fcedb" />
<img width="276" height="136" alt="Screenshot 2025-11-04 at 7 01 40 AM" src="https://github.com/user-attachments/assets/5858bcc6-e9ba-4e68-b8ba-8ebc72d0f9a6" />
<img width="276" height="136" alt="Screenshot 2025-11-04 at 7 01 40 AM" src="https://github.com/user-attachments/assets/bbf43a20-22f8-40b2-b7bd-13e9ed4cc02c" />

