### PR TITLE
fix: default english lang imports

### DIFF
--- a/src/common/flatpickrLangs.ts
+++ b/src/common/flatpickrLangs.ts
@@ -1,5 +1,5 @@
 import { Locale } from 'flatpickr/dist/types/locale';
-import { default as English } from 'flatpickr/dist/l10n/default.js';
+import English from 'flatpickr/dist/l10n/default.js';
 
 export const langsArray = [
   'ar', // Arabic

--- a/src/common/helpers/flatpickr.ts
+++ b/src/common/helpers/flatpickr.ts
@@ -3,7 +3,7 @@ import rangePlugin from 'flatpickr/dist/plugins/rangePlugin';
 import { Instance } from 'flatpickr/dist/types/instance';
 import { BaseOptions, Hook } from 'flatpickr/dist/types/options';
 import { Locale } from 'flatpickr/dist/types/locale';
-import { default as English } from 'flatpickr/dist/l10n/default.js';
+import English from 'flatpickr/dist/l10n/default.js';
 import { loadLocale as loadLocaleFromLangs } from '../flatpickrLangs';
 
 import { fixedOverlayPositionPlugin } from '../helpers/flatpickrOverlayPosition';


### PR DESCRIPTION
## Summary

modify default lang import

`import { default as English } from 'flatpickr/dist/l10n/default.js';`

to

`import English from 'flatpickr/dist/l10n/default.js';`