### PR TITLE
fix: dynamic import implementation for flatpickr langs

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,5 +1,5 @@
 declare module '*.scss' {
-  import type { CSSResultGroup } from 'lit';
+  import { CSSResultGroup } from 'lit';
   const styles: CSSResultGroup;
   export default styles;
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -87,6 +87,7 @@ export default {
   ],
 };
 
+// remove query params from imports so they don't break the build
 function removeQueryParams() {
   return {
     name: 'remove-query-params',


### PR DESCRIPTION
## Summary
Add in `dynamicImportVars` functionality to allow for cleaner flatpickr lang imports. Mimicked from shidoka-charts.

1) clean up declarations file to remove *.svg, *?raw, *?inline declarations; Vite already handles that
2) add `dynamicImprotVars` import and instantiation to rollup.config
3) add `"types": ["vite/client"]` to tsconfig to allow for 4
4) refactor flatpickrLangs file to utilize dynamic imports, reducing code bloat

## Screenshots
<img width="1145" height="534" alt="Screenshot 2025-11-12 at 2 28 24 PM" src="https://github.com/user-attachments/assets/e3c6a391-ffad-499b-90b1-c0caf18ad2f7" />

<img width="1151" height="499" alt="Screenshot 2025-11-12 at 2 28 29 PM" src="https://github.com/user-attachments/assets/e0eac9bd-f647-43ce-aa8c-32bd5dbf885b" />

<img width="1154" height="533" alt="Screenshot 2025-11-12 at 2 28 50 PM" src="https://github.com/user-attachments/assets/83b2ffde-335a-4f40-a691-1de3cfffa19d" />