### PR TITLE
fix(tooltip): edge case handle for kyn-header overlap

### DIFF
--- a/src/components/reusable/tooltip/tooltip.ts
+++ b/src/components/reusable/tooltip/tooltip.ts
@@ -118,6 +118,31 @@ export class Tooltip extends LitElement {
     const ViewportHeight = window.innerHeight;
     const ViewportWidth = window.innerWidth;
 
+    // Edge case handling: When tooltip collide with kyn-header, force the tooltip to render downwards.
+    const header = document.querySelector('kyn-header');
+    const headerRect = header?.getBoundingClientRect();
+    const tooltipHeight = this._contentEl.offsetHeight || 60;
+
+    const isOverlappingHeader =
+      headerRect && AnchorTop - tooltipHeight < headerRect.bottom;
+
+    if (isOverlappingHeader) {
+      this._direction = 'bottom';
+      const center = AnchorLeft + this._anchorEl.offsetWidth / 2;
+
+      if (center < ViewportWidth * 0.33) {
+        this._anchorPosition = 'start';
+      } else if (center < ViewportWidth * 0.66) {
+        this._anchorPosition = 'center';
+      } else {
+        this._anchorPosition = 'end';
+      }
+
+      this._contentEl.style.top = `${AnchorBottom}px`;
+      this._contentEl.style.left = `${center}px`;
+      return;
+    }
+
     let vertical = 'down';
     let horizontal = 'right';
 


### PR DESCRIPTION
## Summary

Edge case handling: When tooltip collide with kyn-header, force the tooltip to render downwards.

## ADO Story or GitHub Issue Link

Link here (if applicable).

## Figma Link

Link here (if applicable).


## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## Screenshots


Original from Bridge Poc 

<img width="972" height="468" alt="image" src="https://github.com/user-attachments/assets/a539ff4a-3e92-482b-83f2-2ae2be8f4dcf" />

## Before Fix (Mimicked the same page as per original for testing purpose)


https://github.com/user-attachments/assets/d619e3b3-3137-4bd0-8d73-3690ac8a9345

## After Fix


https://github.com/user-attachments/assets/20be967a-be1e-4359-b8f1-dc2ad74610b5



