### PR TITLE
fix(progress-bar): update progress when value changes in any status

### DIFF
--- a/src/components/reusable/progressBar/progressBar.ts
+++ b/src/components/reusable/progressBar/progressBar.ts
@@ -198,18 +198,14 @@ export class ProgressBar extends LitElement {
   }
 
   override firstUpdated() {
-    if (this.status === ProgressStatus.ACTIVE) {
-      this.startProgress();
-    }
+    this.startProgress();
   }
 
   override updated(changedProperties: Map<string, any>) {
     if (changedProperties.has('status') || changedProperties.has('value')) {
       this.cancelAnimation();
 
-      if (this.status === ProgressStatus.ACTIVE) {
-        this.startProgress();
-      }
+      this.startProgress();
     }
   }
 


### PR DESCRIPTION
## Summary

When setting status and value simultaneously, progress would not update. Changed to allow progress to update in any status.