### PR TITLE
fix(bug 686): parent checkbox not reflecting state of selections in subgroup

### DIFF
--- a/src/components/reusable/checkbox/checkboxSubgroup.ts
+++ b/src/components/reusable/checkbox/checkboxSubgroup.ts
@@ -39,8 +39,15 @@ export class CheckboxSubgroup extends LitElement {
   }
 
   private _syncParent(count: number) {
-    // sync Parent indeterminate state
-    this._parent[0].indeterminate = count < this._children.length && count > 0;
+    const parent = this._parent?.[0];
+    if (!parent) return;
+
+    // checked when all children are checked, otherwise unchecked
+    parent.checked =
+      this._children.length > 0 && count === this._children.length;
+
+    // indeterminate when some (but not all) children are checked
+    parent.indeterminate = count < this._children.length && count > 0;
   }
 
   private _handleCheckboxChange(e: any) {
@@ -58,12 +65,6 @@ export class CheckboxSubgroup extends LitElement {
 
     if (isParent) {
       checkedBoxesCount = e.detail.checked ? this._children.length : 0;
-    } else {
-      if (e.detail.checked) {
-        checkedBoxesCount += 1;
-      } else {
-        checkedBoxesCount -= 1;
-      }
     }
 
     this._syncParent(checkedBoxesCount);


### PR DESCRIPTION
## Summary

Resolves #686 

Updated `kyn-checkbox-subgroup` to derive the parent checkbox state directly from the current child states on change:
- parent becomes indeterminate when some (but not all) children are checked and checked only when all children are checked
- removes buggy incremental +/- counting that caused the parent to flip incorrectly as more children were selected