### PR TITLE
fix: button ghost selected state

### DIFF
--- a/src/components/reusable/button/button.scss
+++ b/src/components/reusable/button/button.scss
@@ -524,7 +524,9 @@
     }
 
     &.selected {
-      background-color: var(--kd-color-background-secondary-state-selected);
+      background-color: var(
+        --kd-color-background-button-secondary-state-selected
+      ) !important;
       color: var(--kd-color-text-level-light);
     }
   }


### PR DESCRIPTION
## Summary

Ghost button in `selected` state was white text on white background. Matches figma now.
