### PR TITLE
docs: updated netlify img src

### DIFF
--- a/src/stories/welcome.mdx
+++ b/src/stories/welcome.mdx
@@ -32,7 +32,7 @@ This library is built on top of the [Shidoka Foundation](https://github.com/kynd
 
 <a href="https://www.netlify.com">
   <img
-    src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg"
+    src="https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg"
     alt="Deploys by Netlify"
   />
 </a>


### PR DESCRIPTION
## Summary

Netlify img src https://www.netlify.com/v3/img/components/netlify-color-accent.svg seems to be broken. Updated with correct one.

## ADO Story or GitHub Issue Link

Link here (if applicable).

## Figma Link

Link here (if applicable).

## Notes

- Detailed change notes
- can go here

## To Do

- Anything else
- left to do

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Testing Instructions

Provide guidance to reviewers/testers here.

## Screenshots

(if any)
