### PR TITLE
fix(queryBuilder): remove false validation errors for text/email datatypes

### DIFF
--- a/src/components/reusable/queryBuilder/queryBuilderRule.ts
+++ b/src/components/reusable/queryBuilder/queryBuilderRule.ts
@@ -315,7 +315,7 @@ export class QueryBuilderRule extends LitElement {
         placeholder=${field?.placeholder || this.textStrings.value || 'Value'}
         .value=${String(this.rule.value)}
         ?required=${field?.required}
-        pattern=${field?.pattern || ''}
+        pattern=${ifDefined(field?.pattern)}
         minLength=${ifDefined(field?.minLength)}
         maxLength=${ifDefined(field?.maxLength)}
         ?disabled=${this.disabled || this.rule.disabled}
@@ -638,7 +638,7 @@ export class QueryBuilderRule extends LitElement {
           placeholder=${this.textStrings.from || 'From'}
           .value=${String(val1)}
           ?required=${field.required}
-          pattern=${field.pattern || ''}
+          pattern=${ifDefined(field.pattern)}
           minLength=${ifDefined(field.minLength)}
           maxLength=${ifDefined(field.maxLength)}
           ?disabled=${this.disabled || this.rule.disabled}
@@ -655,7 +655,7 @@ export class QueryBuilderRule extends LitElement {
           placeholder=${this.textStrings.to || 'To'}
           .value=${String(val2)}
           ?required=${field.required}
-          pattern=${field.pattern || ''}
+          pattern=${ifDefined(field.pattern)}
           minLength=${ifDefined(field.minLength)}
           maxLength=${ifDefined(field.maxLength)}
           ?disabled=${this.disabled || this.rule.disabled}


### PR DESCRIPTION
resolves #734 

## Summary

The pattern attribute on text inputs was defaulting to an empty string when no pattern was defined, causing any entered value to fail validation. Fixed by using `ifDefined(field?.pattern)` so the pattern attribute is only rendered when explicitly configured by the consuming dev.

## Steps to Reproduce
1. navigate to the Query Builder story in the Storybook sidebar

2. create a rule with a text or email datatype field:

3. select a field that has dataType: `text` (like `First Name`)

4. select an operator (e.g., `Equals`)

5. type any value in the text input

**Before the fix**: The input would immediately show a validation error `"Please match the requested format"` regardless of what was typed:
<img width="1425" height="208" alt="Screenshot 2026-02-04 at 6 16 19 AM" src="https://github.com/user-attachments/assets/bfe6befe-1a1f-439d-a225-d14a7035ccdf" />

**After the fix**: The input should now accept any value without validation errors (unless the field explicitly defines a pattern in its configuration):
<img width="1441" height="147" alt="Screenshot 2026-02-04 at 6 16 09 AM" src="https://github.com/user-attachments/assets/3941d413-a2e0-43ce-b94e-dfca6b254422" />

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file