### PR TITLE
fix(multiInputField): render tag text via label prop instead of slot

### DIFF
--- a/src/components/reusable/multiInputField/multiInputField.ts
+++ b/src/components/reusable/multiInputField/multiInputField.ts
@@ -255,6 +255,7 @@ export class MultiInputField extends FormMixin(LitElement) {
       <kyn-tag
         class="indiv-tag"
         tagColor=${tagColor}
+        label=${item}
         noTruncation
         ?clickable=${!this.readonly && !this.disabled}
         ?disabled=${this.disabled}
@@ -262,7 +263,6 @@ export class MultiInputField extends FormMixin(LitElement) {
         @on-close=${() => this.removeAt(index)}
       >
         ${showIcon ? html`${unsafeSVG(iconSvg)}` : ''}
-        <span>${item}</span>
       </kyn-tag>
     `;
   }


### PR DESCRIPTION
## Summary

Fixed `kyn-multi-input-field` not displaying tag text by passing the item value to `kyn-tag`'s label attribute instead of placing it in the slot. The slot is reserved for icons only, while label is what `kyn-tag` renders as visible text.

## ADO Story or GitHub Issue Link

resolves #738 