### PR TITLE
fix(icon-selector): migrate props from iconSelector to iconSelectorGroup, easier config

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -10936,7 +10936,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "When true, the icon is only visible when the parent element is hovered.\nVisibility is controlled via CSS on the parent component.",
+              "description": "When true, the icon is only visible when the parent element is hovered.\nVisibility is controlled via CSS on the parent component.\nCan also be set via `--kyn-icon-selector-only-visible-on-hover: 1` on an ancestor.",
               "attribute": "onlyVisibleOnHover",
               "reflects": true
             },
@@ -10947,8 +10947,36 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "When true, checked items remain visible even when onlyVisibleOnHover is enabled.\nUseful for showing users which items they've already favorited.",
+              "description": "When true, checked items remain visible even when onlyVisibleOnHover is enabled.\nUseful for showing users which items they've already favorited.\nCan also be set via `--kyn-icon-selector-persist-when-checked: 1` on an ancestor.",
               "attribute": "persistWhenChecked"
+            },
+            {
+              "kind": "field",
+              "name": "animateSelection",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Enables a subtle pop/crossfade animation when toggling checked state.\nCan also be enabled for all descendants by setting the CSS custom property\n`--kyn-icon-selector-animate-selection: 1` on any ancestor element.",
+              "attribute": "animateSelection"
+            },
+            {
+              "kind": "field",
+              "name": "_shouldOnlyVisibleOnHover",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "_shouldPersistWhenChecked",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
             },
             {
               "kind": "method",
@@ -10988,6 +11016,43 @@
                   }
                 }
               ]
+            },
+            {
+              "kind": "field",
+              "name": "_cssResolved",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
+            },
+            {
+              "kind": "method",
+              "name": "_readCSSFlags",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "_cssOnlyVisibleOnHover",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "_cssPersistWhenChecked",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
+            },
+            {
+              "kind": "method",
+              "name": "_resolveFlags",
+              "privacy": "private"
             }
           ],
           "events": [
@@ -11051,7 +11116,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "When true, the icon is only visible when the parent element is hovered.\nVisibility is controlled via CSS on the parent component.",
+              "description": "When true, the icon is only visible when the parent element is hovered.\nVisibility is controlled via CSS on the parent component.\nCan also be set via `--kyn-icon-selector-only-visible-on-hover: 1` on an ancestor.",
               "fieldName": "onlyVisibleOnHover"
             },
             {
@@ -11060,8 +11125,17 @@
                 "text": "boolean"
               },
               "default": "false",
-              "description": "When true, checked items remain visible even when onlyVisibleOnHover is enabled.\nUseful for showing users which items they've already favorited.",
+              "description": "When true, checked items remain visible even when onlyVisibleOnHover is enabled.\nUseful for showing users which items they've already favorited.\nCan also be set via `--kyn-icon-selector-persist-when-checked: 1` on an ancestor.",
               "fieldName": "persistWhenChecked"
+            },
+            {
+              "name": "animateSelection",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Enables a subtle pop/crossfade animation when toggling checked state.\nCan also be enabled for all descendants by setting the CSS custom property\n`--kyn-icon-selector-animate-selection: 1` on any ancestor element.",
+              "fieldName": "animateSelection"
             }
           ],
           "superclass": {
@@ -11150,6 +11224,26 @@
               "reflects": true
             },
             {
+              "kind": "field",
+              "name": "persistWhenChecked",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "When true, checked child icon-selectors remain visible even when onlyVisibleOnHover is enabled.",
+              "attribute": "persistWhenChecked"
+            },
+            {
+              "kind": "field",
+              "name": "animateSelection",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Enables a subtle pop/crossfade animation when toggling checked state on all children.",
+              "attribute": "animateSelection"
+            },
+            {
               "kind": "method",
               "name": "_syncChildrenState",
               "privacy": "private"
@@ -11197,6 +11291,24 @@
               "default": "false",
               "description": "When true, all child icon-selectors are only visible when the parent element is hovered.\nThis propagates the onlyVisibleOnHover attribute to all children.",
               "fieldName": "onlyVisibleOnHover"
+            },
+            {
+              "name": "persistWhenChecked",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "When true, checked child icon-selectors remain visible even when onlyVisibleOnHover is enabled.",
+              "fieldName": "persistWhenChecked"
+            },
+            {
+              "name": "animateSelection",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Enables a subtle pop/crossfade animation when toggling checked state on all children.",
+              "fieldName": "animateSelection"
             }
           ],
           "superclass": {

--- a/src/components/reusable/iconSelector/iconSelector.scss
+++ b/src/components/reusable/iconSelector/iconSelector.scss
@@ -13,6 +13,11 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+
+  &.animate-selection {
+    display: inline-grid;
+    place-items: center;
+  }
   padding: 4px;
   margin: 0;
   border: none;
@@ -65,7 +70,6 @@
   color: currentColor;
   transition: color 150ms ease-out;
 
-  // Let slotted content determine its own dimensions
   ::slotted(svg),
   ::slotted(span),
   svg {
@@ -73,7 +77,6 @@
     fill: currentColor;
   }
 
-  // Show/hide icons based on checked state
   &--unchecked {
     display: flex;
 
@@ -88,5 +91,55 @@
     .icon-selector--checked & {
       display: flex;
     }
+  }
+
+  .animate-selection & {
+    grid-area: 1 / 1;
+    transition: opacity 200ms ease-out, transform 200ms ease-out;
+  }
+
+  .animate-selection &--unchecked {
+    display: flex;
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  .animate-selection .icon-selector--checked &--unchecked,
+  .animate-selection.icon-selector--checked &--unchecked {
+    display: flex;
+    opacity: 0;
+    transform: scale(0.6);
+  }
+
+  .animate-selection &--checked {
+    display: flex;
+    opacity: 0;
+    transform: scale(0.6);
+  }
+
+  .animate-selection .icon-selector--checked &--checked,
+  .animate-selection.icon-selector--checked &--checked {
+    display: flex;
+    opacity: 1;
+    transform: scale(1);
+    animation: icon-pop 450ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+}
+
+@keyframes icon-pop {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.35);
+    opacity: 1;
+  }
+  75% {
+    transform: scale(0.9);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
   }
 }

--- a/src/components/reusable/iconSelector/iconSelectorGroup.stories.js
+++ b/src/components/reusable/iconSelector/iconSelectorGroup.stories.js
@@ -2,7 +2,6 @@ import { html } from 'lit';
 import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js';
 import './index';
 import { action } from 'storybook/actions';
-import { useArgs } from 'storybook/preview-api';
 
 import starOutlineIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/recommend.svg';
 import starFilledIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/recommend-filled.svg';
@@ -18,6 +17,18 @@ export default {
       control: { type: 'select' },
       options: ['vertical', 'horizontal'],
     },
+    disabled: {
+      control: { type: 'boolean' },
+    },
+    onlyVisibleOnHover: {
+      control: { type: 'boolean' },
+    },
+    persistWhenChecked: {
+      control: { type: 'boolean' },
+    },
+    animateSelection: {
+      control: { type: 'boolean' },
+    },
   },
   parameters: {
     design: {
@@ -31,6 +42,9 @@ export const Group = {
   args: {
     direction: 'vertical',
     disabled: false,
+    onlyVisibleOnHover: true,
+    persistWhenChecked: true,
+    animateSelection: true,
   },
   render: (args) => {
     return html`
@@ -54,37 +68,28 @@ export const Group = {
       <kyn-icon-selector-group
         direction=${args.direction}
         ?disabled=${args.disabled}
+        ?onlyVisibleOnHover=${args.onlyVisibleOnHover}
+        ?persistWhenChecked=${args.persistWhenChecked}
+        ?animateSelection=${args.animateSelection}
         @on-change=${(e) => action(e.type)({ value: e.detail.value })}
       >
         <div class="group-hover-container">
           <span>Item One</span>
-          <kyn-icon-selector
-            value="item-1"
-            onlyVisibleOnHover
-            persistWhenChecked
-          >
+          <kyn-icon-selector value="item-1">
             <span slot="icon-unchecked">${unsafeSVG(starOutlineIcon)}</span>
             <span slot="icon-checked">${unsafeSVG(starFilledIcon)}</span>
           </kyn-icon-selector>
         </div>
         <div class="group-hover-container">
           <span>Item Two</span>
-          <kyn-icon-selector
-            value="item-2"
-            onlyVisibleOnHover
-            persistWhenChecked
-          >
+          <kyn-icon-selector value="item-2">
             <span slot="icon-unchecked">${unsafeSVG(starOutlineIcon)}</span>
             <span slot="icon-checked">${unsafeSVG(starFilledIcon)}</span>
           </kyn-icon-selector>
         </div>
         <div class="group-hover-container">
           <span>Item Three</span>
-          <kyn-icon-selector
-            value="item-3"
-            onlyVisibleOnHover
-            persistWhenChecked
-          >
+          <kyn-icon-selector value="item-3">
             <span slot="icon-unchecked">${unsafeSVG(starOutlineIcon)}</span>
             <span slot="icon-checked">${unsafeSVG(starFilledIcon)}</span>
           </kyn-icon-selector>
@@ -127,15 +132,11 @@ export const GroupWithPreselected = {
   args: {
     direction: 'vertical',
     value: ['item-2'],
+    onlyVisibleOnHover: true,
+    persistWhenChecked: true,
+    animateSelection: true,
   },
   render: (args) => {
-    const [, updateArgs] = useArgs();
-
-    const handleChange = (e) => {
-      updateArgs({ value: e.detail.value });
-      action(e.type)({ value: e.detail.value });
-    };
-
     return html`
       <style>
         .group-hover-container {
@@ -157,37 +158,28 @@ export const GroupWithPreselected = {
       <kyn-icon-selector-group
         direction=${args.direction}
         .value=${args.value}
-        @on-change=${handleChange}
+        ?onlyVisibleOnHover=${args.onlyVisibleOnHover}
+        ?persistWhenChecked=${args.persistWhenChecked}
+        ?animateSelection=${args.animateSelection}
+        @on-change=${(e) => action(e.type)({ value: e.detail.value })}
       >
         <div class="group-hover-container">
           <span>Item One</span>
-          <kyn-icon-selector
-            value="item-1"
-            onlyVisibleOnHover
-            persistWhenChecked
-          >
+          <kyn-icon-selector value="item-1">
             <span slot="icon-unchecked">${unsafeSVG(starOutlineIcon)}</span>
             <span slot="icon-checked">${unsafeSVG(starFilledIcon)}</span>
           </kyn-icon-selector>
         </div>
         <div class="group-hover-container">
           <span>Item Two</span>
-          <kyn-icon-selector
-            value="item-2"
-            onlyVisibleOnHover
-            persistWhenChecked
-          >
+          <kyn-icon-selector value="item-2">
             <span slot="icon-unchecked">${unsafeSVG(starOutlineIcon)}</span>
             <span slot="icon-checked">${unsafeSVG(starFilledIcon)}</span>
           </kyn-icon-selector>
         </div>
         <div class="group-hover-container">
           <span>Item Three</span>
-          <kyn-icon-selector
-            value="item-3"
-            onlyVisibleOnHover
-            persistWhenChecked
-          >
+          <kyn-icon-selector value="item-3">
             <span slot="icon-unchecked">${unsafeSVG(starOutlineIcon)}</span>
             <span slot="icon-checked">${unsafeSVG(starFilledIcon)}</span>
           </kyn-icon-selector>

--- a/src/components/reusable/iconSelector/iconSelectorGroup.ts
+++ b/src/components/reusable/iconSelector/iconSelectorGroup.ts
@@ -34,6 +34,16 @@ export class IconSelectorGroup extends LitElement {
   @property({ type: Boolean, reflect: true })
   accessor onlyVisibleOnHover = false;
 
+  /**
+   * When true, checked child icon-selectors remain visible even when onlyVisibleOnHover is enabled.
+   */
+  @property({ type: Boolean })
+  accessor persistWhenChecked = false;
+
+  /** Enables a subtle pop/crossfade animation when toggling checked state on all children. */
+  @property({ type: Boolean })
+  accessor animateSelection = false;
+
   /** Slotted icon selectors.
    * @internal
    */
@@ -76,20 +86,25 @@ export class IconSelectorGroup extends LitElement {
 
   private _syncChildrenState() {
     this._selectors.forEach((selector) => {
-      if (this.disabled) {
-        selector.disabled = true;
-      }
-      if (this.onlyVisibleOnHover) {
-        selector.onlyVisibleOnHover = true;
-      }
+      selector.disabled = this.disabled;
+      selector.onlyVisibleOnHover = this.onlyVisibleOnHover;
+      selector.persistWhenChecked = this.persistWhenChecked;
+      selector.animateSelection = this.animateSelection;
       selector.checked = this.value.includes(selector.value);
     });
   }
 
   /**
    * @internal
+   * Re-entrancy guard for event dispatch.
    */
+  private _dispatching = false;
+
   private _handleChildChange = (e: CustomEvent) => {
+    // prevent re-entrancy: the group's own dispatched on-change
+    // re-triggers this listener since it fires on the same element.
+    if (this._dispatching) return;
+
     // Stop the child event from bubbling further
     e.stopPropagation();
 
@@ -105,6 +120,7 @@ export class IconSelectorGroup extends LitElement {
     this.value = newValue;
 
     // Emit group change event
+    this._dispatching = true;
     this.dispatchEvent(
       new CustomEvent('on-change', {
         composed: true,
@@ -114,13 +130,16 @@ export class IconSelectorGroup extends LitElement {
         },
       })
     );
+    this._dispatching = false;
   };
 
   override updated(changedProperties: Map<string, unknown>) {
     if (
       changedProperties.has('value') ||
       changedProperties.has('disabled') ||
-      changedProperties.has('onlyVisibleOnHover')
+      changedProperties.has('onlyVisibleOnHover') ||
+      changedProperties.has('persistWhenChecked') ||
+      changedProperties.has('animateSelection')
     ) {
       this._syncChildrenState();
     }


### PR DESCRIPTION
## Summary                                                                                                           
                      
 Added `animateSelection` and `persistWhenChecked` props to the icon selector group (propagated to children), with a pop/crossfade animation gated behind animateSelection. All three boolean flags (`animateSelection`, `onlyVisibleOnHover`, `persistWhenChecked`) can also be inherited via CSS custom properties for cross-shadow-DOM configuration. Fixed bug in the group's event handling and a first-render blink when `onlyVisibleOnHover` was active.    
 
**NOTE**: This is an instance where it is technically a breaking change, but the first team to implement this component will be the Global Switcher (upcoming PR), so it is not currently in use anywhere in the org.