### PR TITLE
fix(header-flyout): add menu min-width

### DIFF
--- a/src/components/global/header/header-interactive.scss
+++ b/src/components/global/header/header-interactive.scss
@@ -99,6 +99,7 @@
       border-radius: 8px;
       background: var(--kd-color-background-container-default);
       max-height: calc(100vh - var(--kd-header-reserved-space) - 16px);
+      min-width: 180px;
 
       &.left {
         left: -12px;


### PR DESCRIPTION
## Summary

Add a min-width the header flyout menu to reduce over-aggressive link text wrapping.

resolves #744 