### PR TITLE
fix(querybuilder): unable to import QB in application

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,3 +119,8 @@ export { ColorInput } from './components/reusable/colorInput';
 export { MetaData } from './components/reusable/metaData';
 export { Divider } from './components/reusable/divider';
 export { StatusButton } from './components/reusable/statusButton';
+export {
+  QueryBuilder,
+  QueryBuilderGroup,
+  QueryBuilderRule,
+} from './components/reusable/queryBuilder';


### PR DESCRIPTION
## Summary

When consuming QueryBuilder Application is facing production build issue due to missing export of QueryBuilder in root index.ts 


## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Testing Instructions

Provide guidance to reviewers/testers here.

## Screenshots

(if any)
