### PR TITLE
fix(forms): updated error icon token

### DIFF
--- a/src/common/scss/form-input.scss
+++ b/src/common/scss/form-input.scss
@@ -191,7 +191,7 @@ textarea {
 }
 
 .error-icon {
-  color: var(--kd-color-status-error-dark);
+  color: var(--kd-color-icon-destructive);
 
   [disabled] & {
     color: var(--kd-color-text-level-disabled);

--- a/src/components/reusable/datePicker/datepicker.ts
+++ b/src/components/reusable/datePicker/datepicker.ts
@@ -33,7 +33,7 @@ import { BaseOptions } from 'flatpickr/dist/types/options';
 import DatePickerStyles from './datepicker.scss?inline';
 import ShidokaFlatpickrTheme from '../../../common/scss/shidoka-flatpickr-theme.scss?inline';
 
-import errorIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/close-filled.svg';
+import errorIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/error-filled.svg';
 import calendarIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/24/calendar.svg';
 import clearIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/close-simple.svg';
 

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -36,7 +36,7 @@ import type { Instance } from 'flatpickr/dist/types/instance';
 import DateRangePickerStyles from './daterangepicker.scss?inline';
 import ShidokaFlatpickrTheme from '../../../common/scss/shidoka-flatpickr-theme.scss?inline';
 
-import errorIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/close-filled.svg';
+import errorIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/error-filled.svg';
 import calendarIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/24/calendar.svg';
 import clearIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/close-simple.svg';
 

--- a/src/components/reusable/multiInputField/multiInputField.ts
+++ b/src/components/reusable/multiInputField/multiInputField.ts
@@ -16,7 +16,7 @@ import '../tag';
 
 import MultiInputScss from './multiInputField.scss?inline';
 
-import errorIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/20/error-filled.svg';
+import errorIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/error-filled.svg';
 import userIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/user.svg';
 
 /**

--- a/src/components/reusable/timepicker/timepicker.ts
+++ b/src/components/reusable/timepicker/timepicker.ts
@@ -33,7 +33,7 @@ import ShidokaFlatpickrTheme from '../../../common/scss/shidoka-flatpickr-theme.
 
 import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js';
 
-import errorIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/close-filled.svg';
+import errorIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/error-filled.svg';
 import clockIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/24/time.svg';
 import clearIcon from '@kyndryl-design-system/shidoka-icons/svg/monochrome/16/close-simple.svg';
 


### PR DESCRIPTION
## Summary

1. All Forms component : Updated error icon color token
2. Update error icon size 20 -> 16 for consistency.
3. Datepicker, daterangepicker & timepicker - updated closed filled icon to error filled icon for consistency.

## GitHub Issue Link

[AB#2845880](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2845880)

## Figma Link

[Figma](https://www.figma.com/design/5yRWazF2X4RM8vG8fu4V0f/Marshmallow-2.11?node-id=2-13&p=f&m=dev)



## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## Screenshots

(if any)
