### PR TITLE
fix(accordion): dropdown menu clipped fix

### DIFF
--- a/src/components/reusable/accordion/accordionItem.scss
+++ b/src/components/reusable/accordion/accordionItem.scss
@@ -197,6 +197,7 @@ slot[name='icon']::slotted(span) {
   transition: padding 220ms ease;
 
   .opened & {
+    overflow: visible;
     padding-top: var(--kyn-accordion-item-body-padding-top);
     padding-bottom: var(--kyn-accordion-item-body-padding-bottom);
   }


### PR DESCRIPTION
## Summary

As reported on teams

<img width="877" height="435" alt="image" src="https://github.com/user-attachments/assets/87654c79-86ce-4ec8-9b15-ca4650e37f0c" />



## RCA

`.kyn-accordion-item-detail {overflow: hidden;.....}` makes body dropdown menu clipped inside the container. 
  
  Resolution  :  Added `.opened & {overflow: visible;......}` to overflow dropdown menu outside the container.

## GitHub Issue Link

resolves https://github.com/kyndryl-design-system/shidoka-applications/issues/842

## Figma Link

Link here (if applicable).

## Notes

- Detailed change notes
- can go here

## To Do

- Anything else
- left to do

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## Screen Recording 

https://github.com/user-attachments/assets/963e1cdb-57e3-4c84-b809-9f34c4700dea


