### PR TITLE
fix(overflow): truncated text tooltip and overlap with chevron icon

### DIFF
--- a/src/components/reusable/overflowMenu/overflowMenuItem.scss
+++ b/src/components/reusable/overflowMenu/overflowMenuItem.scss
@@ -25,6 +25,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   transition: background-color 0.15s ease-out, outline-color 0.15s ease-out;
+  &.has-submenu {
+    padding-right: 30px;
+  }
 }
 
 .sr-only {

--- a/src/components/reusable/overflowMenu/overflowMenuItem.ts
+++ b/src/components/reusable/overflowMenu/overflowMenuItem.ts
@@ -109,6 +109,7 @@ export class OverflowMenuItem extends LitElement {
       'menu-item': true,
       'ai-connected': this.kind === 'ai',
       destructive: this.destructive,
+      'has-submenu': this.hasSubmenu,
     };
 
     const itemText = this.isTruncated ? this.tooltipText : '';
@@ -184,7 +185,6 @@ export class OverflowMenuItem extends LitElement {
         });
       });
     }
-
     this.checkOverflow();
   }
 
@@ -270,7 +270,28 @@ export class OverflowMenuItem extends LitElement {
       this.isTruncated =
         contentElement.scrollWidth > contentElement.offsetWidth;
       if (this.isTruncated) {
-        this.tooltipText = (this.textContent ?? '').trim();
+        const slot = this.shadowRoot?.querySelector(
+          '.text slot'
+        ) as HTMLSlotElement;
+        const nodes = slot.assignedNodes({ flatten: false });
+
+        const text = nodes //get all text content from the slot,but ignore any nested submenu content
+          .filter((node) => {
+            return (
+              node.nodeType === Node.TEXT_NODE ||
+              (node.nodeType === Node.ELEMENT_NODE &&
+                !(node as HTMLElement).hasAttribute('slot'))
+            );
+          })
+          .map((node) => {
+            if (node.nodeType === Node.TEXT_NODE) {
+              return node.textContent || '';
+            }
+            return (node as HTMLElement).innerText || '';
+          })
+          .join('')
+          .trim();
+        this.tooltipText = text;
       }
     }
   }


### PR DESCRIPTION
## Summary

Brief summary describing the changes here.

## GitHub Issue Link

[AB#2984169](https://dev.azure.com/Kyndryl/f7f7ab25-06ec-43dc-902d-dee2e157cebd/_workitems/edit/2984169)

resolves https://github.com/kyndryl-design-system/shidoka-applications/issues/847


## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [x] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## ScreenRecording

https://github.com/user-attachments/assets/63beabf6-b2ea-41a2-9d60-2495e31232f9


