### PR TITLE
fix: padding adjustment in mini popover

### DIFF
--- a/src/components/reusable/popover/popover.scss
+++ b/src/components/reusable/popover/popover.scss
@@ -63,7 +63,7 @@
   width: var(--kyn-popover-mini-width);
   min-width: 0;
   max-width: var(--kyn-popover-mini-max-width);
-  padding: 15px;
+  padding: 12px;
   display: flex;
   align-items: center;
   gap: 8px;


### PR DESCRIPTION
Addresses [AB#3016204](https://dev.azure.com/Kyndryl/f7f7ab25-06ec-43dc-902d-dee2e157cebd/_workitems/edit/3016204)

## Summary
- fix padding on popover mini

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [x] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots

#### BEFORE
<img width="373" height="187" alt="Screenshot 2026-06-01 at 12 26 48 PM" src="https://github.com/user-attachments/assets/7cf4de7e-e70f-4894-a5f4-3311211a186e" />

#### AFTER
<img width="1206" height="449" alt="Screenshot 2026-06-01 at 12 27 10 PM" src="https://github.com/user-attachments/assets/e08e52ff-3868-42ca-a78e-dc2b633fe47e" />