### PR TITLE
chore(tag): clean up clickable logic, not clickable by default

### DIFF
--- a/src/components/reusable/tag/Docs.mdx
+++ b/src/components/reusable/tag/Docs.mdx
@@ -53,7 +53,8 @@ Tag.
 
 ### Properties
 
-- By default, new tags are `clickable`.
+- By default, tags are not `clickable`.
+- Set `clickable` to `true` to make a tag clickable.
 - Setting `filter` to `true` **overrides** `clickable`.
 - **tagColor** - `spruce` now follows new tag colour and styling.
 

--- a/src/components/reusable/tag/tag.ts
+++ b/src/components/reusable/tag/tag.ts
@@ -186,7 +186,7 @@ export class Tag extends LitElement {
 
   private _isTagClickable() {
     if (this._checkForNewTag()) {
-      return !this.filter && this.clickable;
+      return !this.filter;
     } else {
       return this.clickable;
     }

--- a/src/components/reusable/tag/tag.ts
+++ b/src/components/reusable/tag/tag.ts
@@ -54,9 +54,7 @@ export class Tag extends LitElement {
   accessor noTruncation = false;
 
   /**
-   * Determine if Tag is clickable(applicable for old tags only).
-   * <br>
-   * **NOTE**: New tags are **clickable** by **default**.
+   * Determine if Tag is clickable.
    */
   @property({ type: Boolean })
   accessor clickable = false;
@@ -86,8 +84,8 @@ export class Tag extends LitElement {
     const tagClasses = {
       tags: true,
       'tag-disable': this.disabled,
-      'tag-clickable': this.clickable,
-      [`tag-clickable-${this.tagColor}`]: this.clickable,
+      'tag-clickable': this._isTagClickable(),
+      [`tag-clickable-${this.tagColor}`]: this._isTagClickable(),
       [`${baseColorClass}`]: true,
       [`${sizeClass}`]: true,
       [`${sizeClass}-filter`]: this.filter,
@@ -185,11 +183,7 @@ export class Tag extends LitElement {
   }
 
   private _isTagClickable() {
-    if (this._checkForNewTag()) {
-      return !this.filter;
-    } else {
-      return this.clickable;
-    }
+    return this.clickable && !this.filter;
   }
 
   private handleTagClear(e: any, value: string) {


### PR DESCRIPTION
resolves #876

All tags will be not clickable by default and docs updated to reflect that