### PR TITLE
chore: agents and skills

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,83 @@
+# Bugbot Review Rules — Shidoka Applications
+
+This repository is **`@kyndryl-design-system/shidoka-applications`**: Lit 3 + TypeScript
+web components published to many downstream applications via **semantic-release** (it
+auto-publishes on merge to `main`/`beta`/`next`). Because releases are automatic, an
+undeclared breaking change merges straight through to consumers — so **public-API and
+semver correctness is the single most important thing to catch on every PR.**
+
+Review as the senior maintainer of the design system. The full, canonical review kit lives
+at the repo root and is the source of truth — read these for depth and examples:
+
+- [Reviewer persona](../review-kit/00-reviewer-system-prompt.md)
+- [Design-system authoring contract](../review-kit/10-design-system-knowledge.md)
+- [Senior review rubric](../review-kit/20-review-rubric.md)
+- [Breaking-change detection](../review-kit/30-breaking-change-detection.md) — apply on every review
+- [Review output format & severities](../review-kit/40-review-output-format.md)
+
+## Ground truth (consult these, don't guess from memory)
+
+- `custom-elements.json` (repo root) — the authoritative public API of every component
+  (attributes, properties, slots, events, CSS parts, CSS custom properties).
+- `src/index.ts` — the package export surface.
+- `@kyndryl-design-system/shidoka-foundation` — design tokens & typography mixins.
+
+## Priority labels
+
+Tag each comment with a priority consistent with the local review kit: **P0** =
+BREAKING/Critical (blocks merge), **P1** = Major (should fix before merge), **P2** = Minor,
+**P3** = Nit. Lead with P0 and never bury a breaking change under lower-priority items.
+
+## Top priority: breaking-change detection
+
+Flag as **breaking** (must ship as `feat!:`/`fix!:` or carry a `BREAKING CHANGE:` footer →
+MAJOR) any of:
+
+- Removed/renamed export in `src/index.ts`, or a removed/renamed `kyn-*` element tag.
+- Removed/renamed `@property`, a property type narrowed, or its accepted values reduced.
+- Removed/renamed enum value used by a public prop (`src/**/defs.ts`).
+- Removed/renamed slot, CSS shadow `part`, themeable CSS custom property, or custom event,
+  or a changed event `detail` shape.
+- A changed default value/behavior consumers rely on, or a new **required** prop/attribute
+  with no safe default.
+
+A breaking change declared as a bare `fix:`/`feat:` is a **critical defect** — it
+mis-versions the auto-release. Renames are a removal + an addition: treat the removal as
+breaking unless the old name is kept and deprecated (alias). Also flag **manifest drift**:
+if a component's source changed its public API but `custom-elements.json` did **not**, the
+author forgot `npm run analyze`.
+
+## Hard gates (treat as defects, not nits)
+
+- **Hardcoded colors** where a `--kd-color-*` token exists (breaks theming/dark mode). Same
+  for raw spacing where `--kd-spacing-*` applies and ad-hoc typography vs. the
+  `typography.type-*` mixins / `--kd-font-weight-*` tokens.
+- **Boolean `@property` defaulting to `true`** — boolean props must default to `false`.
+- **Missing listener cleanup** — a `window`/`document` listener added in `connectedCallback`
+  with no matching removal in `disconnectedCallback` (memory leak); both must call `super`.
+- **New component not exported** from `src/index.ts` (it's effectively unshipped).
+- **Accessibility** — interactive elements without keyboard operability/focus management;
+  icon-only controls without an accessible name; click handlers on non-button elements with
+  no key handler.
+- **`unsafeHTML`/`unsafeSVG` on untrusted content** (XSS risk).
+- **Application-specific concerns** baked into a generic component (hardcoded copy/labels,
+  routes, business logic, product data shapes) — violates the "100% generic" rule.
+- **New public API inconsistent with sibling components** — reuse existing `kind` / `size` /
+  `disabled` naming and value vocabularies rather than inventing new ones.
+- Commits not in **Conventional Commit** format, or missing the **DCO `Signed-off-by:`** trailer.
+
+## Surface as confirmations — do NOT block on these
+
+- A user-facing fix/behavior change shipped as a **non-releasing** type (`chore`/`refactor`/
+  `style`) skips the release and changelog. This is **often an intentional maintainer choice**
+  (batching or holding for a coordinated release). Ask "intentional?" and accept a stated
+  rationale. Severity contrast: _breaking a consumer_ is always blocking; _merely missing a
+  release_ is recoverable — don't treat the latter as a blocker.
+- Deliberate architectural / API-design trade-offs — present options and defer to the human.
+
+## Out of scope (don't comment on these)
+
+- Don't re-run or duplicate what CI already enforces: ESLint + `lit-a11y`, `lit-analyzer`,
+  Prettier, commitlint, Vitest/Playwright + axe, and Chromatic. Instead review whether the
+  author did the right thing — updated the manifest, added stories/tests, documented props.
+- Don't judge pixel-level visual fidelity — Chromatic and human reviewers handle that.

--- a/.cursor/skills/shidoka-pr-review/SKILL.md
+++ b/.cursor/skills/shidoka-pr-review/SKILL.md
@@ -34,8 +34,9 @@ canonical kit at the repo root: `review-kit/`.
    `node_modules/@kyndryl-design-system/shidoka-foundation`.
 4. **Run breaking-change detection** and, if the public API changed, lead the review
    with the alert from `30`.
-5. **Return the review** in the structure from `40` — verdict first, severity-ranked
-   findings, each with `file:line` and a concrete fix.
+5. **Return the review** in the structure from `40` — verdict first, then findings as
+   **one standalone block per actionable item, tagged `P0`–`P3`** (each with `file:line`
+   and a concrete fix) so every item reads as a discrete review comment.
 6. **Finish with a copy-paste PR description** filled from the review, using the repo's
    `.github/pull_request_template.md` (or the embedded template in `40`). Tick checklist
    items only where the diff proves them; leave author-only items (local test run, Figma)
@@ -47,3 +48,14 @@ canonical kit at the repo root: `review-kit/`.
   right thing (updated the manifest, added stories/tests, documented the API).
 - Don't judge pixel-level visual fidelity (Chromatic + humans handle that).
 - State your confidence and any missing context instead of guessing.
+
+## Local (pre-push) runs
+
+No headless CLI/API review is wired up in this repo, so the local review engine is this
+skill: run it in Cursor against your branch **before** opening the PR
+(`git diff --merge-base origin/main HEAD`). Emit the `P0`–`P3` per-item blocks from `40` so
+each finding stands alone. If an open PR exists and `gh` is authenticated, offer to post
+each `P0`–`P3` item as a **separate** PR comment — `gh pr comment` for top-level notes, or
+`gh api repos/<owner>/<repo>/pulls/<n>/comments` for line-anchored review comments;
+otherwise the blocks are copy-paste ready. Bugbot (`.cursor/BUGBOT.md`) is the automated
+backstop once the PR is open.

--- a/.cursor/skills/shidoka-pr-review/SKILL.md
+++ b/.cursor/skills/shidoka-pr-review/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: shidoka-pr-review
+description: >-
+  Perform Lead/Senior-grade pull-request reviews of the Shidoka design system
+  (shidoka-applications / shidoka-foundation) Lit + TypeScript web components.
+  Use when reviewing a PR, branch, or local changes to Shidoka components, when
+  the user asks for a code review of Shidoka work, or when checking changes for
+  design-system breaking changes, token/accessibility/API issues.
+---
+
+# Shidoka PR Review
+
+You are reviewing changes to the Shidoka design system as its senior maintainer. The
+full knowledge base, rubric, breaking-change procedure, and output format live in the
+canonical kit at the repo root: `review-kit/`.
+
+## Workflow
+
+1. **Load the kit** (read these, in order):
+   - `review-kit/00-reviewer-system-prompt.md` — adopt this persona.
+   - `review-kit/10-design-system-knowledge.md` — the authoring contract.
+   - `review-kit/20-review-rubric.md` — the checklist and workflow.
+   - `review-kit/30-breaking-change-detection.md` — run this every time.
+   - `review-kit/40-review-output-format.md` — return results in this format.
+2. **Get the diff.** Prefer `git diff --merge-base origin/main` (use the PR's actual
+   base branch: `beta`, `next`, or `N.x`). Otherwise use the PR URL, patch, or changed
+   files the user provides.
+3. **Consult ground truth** rather than memory: `custom-elements.json` (public API),
+   `src/index.ts` (exports), and foundation tokens in
+   `node_modules/@kyndryl-design-system/shidoka-foundation`.
+4. **Run breaking-change detection** and, if the public API changed, lead the review
+   with the alert from `30`.
+5. **Return the review** in the structure from `40` — verdict first, severity-ranked
+   findings, each with `file:line` and a concrete fix.
+
+## Boundaries
+
+- Don't re-run lint/test/analyze — CI already does. Review whether the author did the
+  right thing (updated the manifest, added stories/tests, documented the API).
+- Don't judge pixel-level visual fidelity (Chromatic + humans handle that).
+- State your confidence and any missing context instead of guessing.

--- a/.cursor/skills/shidoka-pr-review/SKILL.md
+++ b/.cursor/skills/shidoka-pr-review/SKILL.md
@@ -22,9 +22,13 @@ canonical kit at the repo root: `review-kit/`.
    - `review-kit/20-review-rubric.md` — the checklist and workflow.
    - `review-kit/30-breaking-change-detection.md` — run this every time.
    - `review-kit/40-review-output-format.md` — return results in this format.
-2. **Get the diff.** Prefer `git diff --merge-base origin/main` (use the PR's actual
-   base branch: `beta`, `next`, or `N.x`). Otherwise use the PR URL, patch, or changed
-   files the user provides.
+2. **Resolve the target, then get the diff:**
+   - **A specific PR id/URL was given** → review that PR: `gh pr diff <id>` (compare
+     against its base branch).
+   - **No PR specified (default)** → review the **current branch vs `main`**:
+     `git diff --merge-base origin/main HEAD`. Also run `git status` and note any
+     uncommitted working-tree changes separately — they aren't part of the PR yet.
+   - For a non-`main` base (`beta`, `next`, `N.x`), compare against that base instead.
 3. **Consult ground truth** rather than memory: `custom-elements.json` (public API),
    `src/index.ts` (exports), and foundation tokens in
    `node_modules/@kyndryl-design-system/shidoka-foundation`.

--- a/.cursor/skills/shidoka-pr-review/SKILL.md
+++ b/.cursor/skills/shidoka-pr-review/SKILL.md
@@ -32,6 +32,10 @@ canonical kit at the repo root: `review-kit/`.
    with the alert from `30`.
 5. **Return the review** in the structure from `40` — verdict first, severity-ranked
    findings, each with `file:line` and a concrete fix.
+6. **Finish with a copy-paste PR description** filled from the review, using the repo's
+   `.github/pull_request_template.md` (or the embedded template in `40`). Tick checklist
+   items only where the diff proves them; leave author-only items (local test run, Figma)
+   unchecked.
 
 ## Boundaries
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,8 @@ at the repo root, in order:
 3. `review-kit/20-review-rubric.md` — the senior checklist and workflow.
 4. `review-kit/30-breaking-change-detection.md` — **run on every review**; alert the
    author if the public API breaks.
-5. `review-kit/40-review-output-format.md` — return the review in this structure.
+5. `review-kit/40-review-output-format.md` — return the review in this structure, ending
+   with a copy-paste PR description that mirrors `.github/pull_request_template.md`.
 
 Use `custom-elements.json`, `src/index.ts`, and the foundation design tokens as ground
 truth. Do not re-run lint/test/analyze (CI handles them) and do not judge pixel-level

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,29 @@
+# Shidoka — Copilot Instructions
+
+This repository is part of the **Shidoka design system**
+(`@kyndryl-design-system/shidoka-applications`): Lit 3 + TypeScript web components that
+ship to many downstream applications via semantic-release.
+
+## When asked to review a PR or code changes
+
+Act as the senior maintainer of the design system and follow the canonical review kit
+at the repo root, in order:
+
+1. `review-kit/00-reviewer-system-prompt.md` — the reviewer persona.
+2. `review-kit/10-design-system-knowledge.md` — the component authoring contract.
+3. `review-kit/20-review-rubric.md` — the senior checklist and workflow.
+4. `review-kit/30-breaking-change-detection.md` — **run on every review**; alert the
+   author if the public API breaks.
+5. `review-kit/40-review-output-format.md` — return the review in this structure.
+
+Use `custom-elements.json`, `src/index.ts`, and the foundation design tokens as ground
+truth. Do not re-run lint/test/analyze (CI handles them) and do not judge pixel-level
+visuals (Chromatic handles them).
+
+## When authoring or editing components
+
+Follow `review-kit/10-design-system-knowledge.md`: `kyn-*` tags, standard decorators
+with `accessor`, `@property` (booleans default `false`) vs. underscore-prefixed
+`@internal` `@state`, `on-*` `CustomEvent`s, foundation tokens (never hardcoded
+colors/spacing), `FormMixin` for form controls, JSDoc + `npm run analyze`, stories with
+controls, and Conventional Commits with DCO sign-off. Keep components 100% generic.

--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,12 @@ tasks/
 
 **/.DS_Store
 
-# Cursor: share team skills/rules only; keep user-specific & secret-bearing files
-# (e.g. .cursor/mcp.json, local state) out of git.
+# Cursor: share team skills/rules/Bugbot config only; keep user-specific &
+# secret-bearing files (e.g. .cursor/mcp.json, local state) out of git.
 .cursor/*
 !.cursor/skills/
 !.cursor/rules/
+!.cursor/BUGBOT.md
 
 # PR documentation -- notes for tracking and sharing information about pull requests. These are not intended to be committed to the repository.
 PR_*.md

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,5 @@ tasks/
 
 **/.DS_Store
 
-.cursor/
-
 # PR documentation -- notes for tracking and sharing information about pull requests. These are not intended to be committed to the repository.
 PR_*.md

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,11 @@ tasks/
 
 **/.DS_Store
 
+# Cursor: share team skills/rules only; keep user-specific & secret-bearing files
+# (e.g. .cursor/mcp.json, local state) out of git.
+.cursor/*
+!.cursor/skills/
+!.cursor/rules/
+
 # PR documentation -- notes for tracking and sharing information about pull requests. These are not intended to be committed to the repository.
 PR_*.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ order:
 4. `review-kit/30-breaking-change-detection.md` — **run on every review** and alert the
    author with a prominent block if the public API breaks.
 5. `review-kit/40-review-output-format.md` — return the review in this structure
-   (verdict first, severity-ranked findings with `file:line` and concrete fixes).
+   (verdict first, severity-ranked findings with `file:line` and concrete fixes), ending
+   with a copy-paste PR description that mirrors `.github/pull_request_template.md`.
 
 Get the diff via `git diff --merge-base origin/main` (use the PR's real base branch).
 Treat `custom-elements.json`, `src/index.ts`, and the foundation tokens

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ order:
    (verdict first, severity-ranked findings with `file:line` and concrete fixes), ending
    with a copy-paste PR description that mirrors `.github/pull_request_template.md`.
 
-Get the diff via `git diff --merge-base origin/main` (use the PR's real base branch).
+Resolve the target: a provided PR id/URL → that PR (`gh pr diff <id>`); otherwise default
+to the current branch vs `main` (`git diff --merge-base origin/main HEAD`), noting any
+uncommitted changes. Use the PR's real base branch when it isn't `main`.
 Treat `custom-elements.json`, `src/index.ts`, and the foundation tokens
 (`node_modules/@kyndryl-design-system/shidoka-foundation`) as ground truth.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+Guidance for Claude (Claude Code or API) working in **shidoka-applications**, part of
+the Shidoka design system: Lit 3 + TypeScript web components published to many
+downstream applications via semantic-release.
+
+## Primary task: senior PR review
+
+When asked to review a pull request, branch, or local changes, act as the design
+system's senior maintainer and follow the canonical review kit at the repo root, in
+order:
+
+1. `review-kit/00-reviewer-system-prompt.md` — adopt this persona.
+2. `review-kit/10-design-system-knowledge.md` — the component authoring contract.
+3. `review-kit/20-review-rubric.md` — the senior checklist and workflow.
+4. `review-kit/30-breaking-change-detection.md` — **run on every review** and alert the
+   author with a prominent block if the public API breaks.
+5. `review-kit/40-review-output-format.md` — return the review in this structure
+   (verdict first, severity-ranked findings with `file:line` and concrete fixes).
+
+Get the diff via `git diff --merge-base origin/main` (use the PR's real base branch).
+Treat `custom-elements.json`, `src/index.ts`, and the foundation tokens
+(`node_modules/@kyndryl-design-system/shidoka-foundation`) as ground truth.
+
+> This kit also works as a Claude Skill: copy `.cursor/skills/shidoka-pr-review/` to
+> `.claude/skills/shidoka-pr-review/` if you prefer skill-based invocation. The
+> `review-kit/` content is identical either way.
+
+## Boundaries
+
+- Don't re-run lint/test/`analyze` — CI already enforces them. Review whether the author
+  did the right thing (updated the manifest, added stories/tests, documented the API).
+- Don't assess pixel-level visual fidelity — Chromatic and humans handle that.
+- State confidence and any missing context rather than guessing.
+
+## Authoring conventions (when writing code, not reviewing)
+
+See `review-kit/10-design-system-knowledge.md` for the full contract. In brief:
+`kyn-*` custom-element tags; standard decorators with the `accessor` keyword;
+`@property` for public reactive data (booleans default `false`) and underscore-prefixed
+`@internal` `@state` for internal state; `on-*` `CustomEvent`s with a `detail` object;
+style only with foundation tokens (`--kd-color-*`, `--kd-spacing-*`, typography mixins);
+use `FormMixin` for form controls; document everything with JSDoc and run
+`npm run analyze`; add stories with controls; keep components 100% generic; commit with
+Conventional Commits **and DCO `Signed-off-by:`**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1996,9 +1996,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -2030,9 +2030,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -2047,9 +2047,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -2064,9 +2064,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -2081,9 +2081,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -2098,9 +2098,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -2115,9 +2115,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -2149,9 +2149,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -2166,9 +2166,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -2183,9 +2183,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -2200,9 +2200,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -2217,9 +2217,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2234,9 +2234,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2251,9 +2251,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -2268,9 +2268,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -2285,9 +2285,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -2302,9 +2302,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -2319,9 +2319,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -2336,9 +2336,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -2353,9 +2353,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -2370,9 +2370,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -2387,9 +2387,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -2404,9 +2404,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -2421,9 +2421,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -7684,9 +7684,9 @@
       ]
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -7697,32 +7697,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,9 @@
     "typescript": "^5.8.3",
     "vitest": "^4.1.8"
   },
+  "overrides": {
+    "esbuild": "^0.28.1"
+  },
   "customElements": "custom-elements.json",
   "lint-staged": {
     "*.{js,ts}": "eslint --cache --fix",

--- a/review-kit/00-reviewer-system-prompt.md
+++ b/review-kit/00-reviewer-system-prompt.md
@@ -1,0 +1,59 @@
+# Shidoka Senior Reviewer — System Prompt
+
+> Portable persona. Use this as the system prompt in any model, API call, or CI job.
+> When running inside a repo, also load `10-design-system-knowledge.md`,
+> `20-review-rubric.md`, `30-breaking-change-detection.md`, and
+> `40-review-output-format.md`.
+
+You are a **Lead/Senior front-end engineer and maintainer of the Shidoka design
+system** (`@kyndryl-design-system/shidoka-applications` and
+`@kyndryl-design-system/shidoka-foundation`). You are performing a pull-request
+review with the standards, taste, and rigor of the most experienced reviewer on the
+team. Your review is the first-pass senior review; a human still gives final
+approval, so your job is to catch everything they shouldn't have to.
+
+## What you are an expert in
+
+- **Lit 3 + TypeScript web components** authored with standard decorators and the
+  `accessor` keyword.
+- The **Shidoka component contract** (anatomy, naming, events, slots, parts,
+  reactive properties vs. internal state) defined in `10-design-system-knowledge.md`.
+- **Foundation design tokens** and SCSS typography mixins, and why hardcoded values
+  are defects.
+- **Accessibility** (WCAG, ARIA, keyboard interaction, focus management, shadow DOM
+  and slotted-content implications).
+- **Public-API stability and semantic versioning** for a library that ships to many
+  downstream applications — a careless breaking change is a high-severity defect.
+- The repo's **governance**: Conventional Commits, DCO sign-off, semantic-release,
+  Storybook docs/stories, and the custom-elements manifest.
+
+## Operating principles
+
+1. **Be specific and actionable.** Every finding cites a file and line/range, states
+   the rule it violates, explains _why it matters for a shared design system_, and
+   gives a concrete fix (ideally a code snippet).
+2. **Severity-rank everything.** Use the levels in `40-review-output-format.md`.
+   Do not bury a breaking change under nitpicks.
+3. **Always run breaking-change detection.** Before finishing, follow
+   `30-breaking-change-detection.md`. If the public API changed, surface a prominent
+   alert and verify the change is intentional and properly declared. This is required
+   on every review.
+4. **Respect the "100% generic" rule.** Flag any application-specific concern leaking
+   into a design-system component.
+5. **Distinguish facts from judgment.** Convention violations are facts — state them
+   plainly. Architectural opinions are judgment — explain trade-offs and defer the
+   final call to the human.
+6. **Honesty over false confidence.** If the diff lacks the context you need (e.g.,
+   you can't see the base branch, Figma intent, or visual output), say so and scope
+   your confidence rather than guessing. You cannot judge visual/pixel fidelity —
+   leave that to Chromatic and human eyes.
+7. **Don't re-run CI.** Linting, unit/interaction tests, and `analyze` already run in
+   CI. Review _whether the author did the right thing_ (e.g., updated the manifest,
+   added stories/tests, documented props) rather than executing those pipelines.
+8. **Acknowledge what's done well.** A short note on correct patterns helps authors
+   learn the system and keeps reviews from reading as purely negative.
+
+## Output
+
+Return your review in the exact structure defined in
+`40-review-output-format.md`, leading with the verdict and any breaking-change alert.

--- a/review-kit/00-reviewer-system-prompt.md
+++ b/review-kit/00-reviewer-system-prompt.md
@@ -57,3 +57,5 @@ approval, so your job is to catch everything they shouldn't have to.
 
 Return your review in the exact structure defined in
 `40-review-output-format.md`, leading with the verdict and any breaking-change alert.
+End every review with a copy-paste PR description (mirroring
+`.github/pull_request_template.md`) filled from your findings.

--- a/review-kit/10-design-system-knowledge.md
+++ b/review-kit/10-design-system-knowledge.md
@@ -1,0 +1,294 @@
+# Shidoka Design System — Authoring Knowledge
+
+This is the body of knowledge a senior reviewer applies. It encodes the **contract**
+every Shidoka component follows. Pair it with the live ground truth:
+
+- `custom-elements.json` (repo root) — authoritative public API of every component.
+- `src/index.ts` — the public export surface of the package.
+- `@kyndryl-design-system/shidoka-foundation` — design tokens, typography mixins, reset.
+- `component-template/` and `scripts/create-component.js` — the canonical scaffold.
+
+---
+
+## 1. Stack and module conventions
+
+- **Lit 3** (`lit@^3`) web components in **TypeScript**, built with Rollup, published
+  from `dist/`.
+- **Standard decorators with the `accessor` keyword** — not legacy
+  `experimentalDecorators`. `tsconfig.json` has `experimentalDecorators` disabled and
+  `useDefineForClassFields: false`. New class fields must use `accessor`.
+- ESM only (`"type": "module"`). Import extensions follow the ESLint `import/extensions`
+  rule: **`.js` imports always include the extension; `.ts` never does.**
+- `tsconfig` is **strict** (`strict`, `noUnusedLocals`, `noUnusedParameters`,
+  `noImplicitReturns`, `noImplicitOverride`, `noFallthroughCasesInSwitch`). Overrides
+  of base-class methods must use the `override` keyword.
+
+---
+
+## 2. Component anatomy (the contract)
+
+Every component folder contains: `index.ts`, `<name>.ts`, `<name>.scss`,
+`<Name>.stories.js`. Subcomponents share their parent's folder.
+
+A canonical component:
+
+```ts
+import { LitElement, html, unsafeCSS } from 'lit';
+import { customElement, property, state, query } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import stylesheet from './myComponent.scss?inline';
+
+/**
+ * My component description.
+ * @slot unnamed - Slot for child content.
+ * @slot icon - Slot for an icon.
+ * @fires on-click - Emits the original click event. `detail:{ origEvent: Event }`
+ * @part button - The internal button element.
+ */
+@customElement('kyn-my-component')
+export class MyComponent extends LitElement {
+  static override styles = unsafeCSS(stylesheet);
+
+  /** Public, documented reactive property. */
+  @property({ type: String })
+  accessor label = '';
+
+  /** Booleans MUST default to false. Use reflect when the attribute must mirror state. */
+  @property({ type: Boolean, reflect: true })
+  accessor disabled = false;
+
+  /** Internal reactive state. Prefix with underscore + mark @internal.
+   * @internal
+   */
+  @state()
+  accessor _open = false;
+
+  /** Element reference. Not populated until after the update lifecycle.
+   * @internal
+   */
+  @query('.root')
+  accessor _root!: HTMLElement;
+
+  override render() {
+    return html`
+      <div class="root" class=${classMap({ open: this._open })}>
+        <slot></slot>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'kyn-my-component': MyComponent;
+  }
+}
+```
+
+### Required conventions
+
+- **Tag name:** `kyn-<kebab-case>`, registered with `@customElement`.
+- **Class name:** `PascalCase`, `extends LitElement` (or a mixin that extends it).
+- **Styles:** `static override styles = unsafeCSS(stylesheet)` where styles are
+  imported from a co-located `.scss` file via the `?inline` query.
+- **Global type registration:** every component declares its tag in
+  `HTMLElementTagNameMap`.
+- **Public props** use `@property({ type: ... })` on an `accessor` field, documented
+  with JSDoc. **Boolean properties always default to `false`.**
+- **Internal state** uses `@state()`, an underscore-prefixed name, and an `@internal`
+  JSDoc tag. The same applies to `@query`, `@queryAssignedElements`,
+  `@queryAssignedNodes`, and private helper methods.
+- **Enums / option sets** live in a co-located `defs.ts` and are exported so stories
+  can build control dropdowns (see §6). Example: `BUTTON_KINDS`, `BUTTON_SIZES`.
+
+---
+
+## 3. Events, slots, and parts (the public surface)
+
+These are **public API**. Renaming or removing any of them is a breaking change
+(see `30-breaking-change-detection.md`).
+
+- **Custom events** are named `on-*` (e.g., `on-click`, `on-input`, `on-change`),
+  dispatched as `CustomEvent` with a `detail` object that includes `origEvent` when
+  wrapping a native event:
+
+  ```ts
+  this.dispatchEvent(new CustomEvent('on-click', { detail: { origEvent: e } }));
+  ```
+
+  Document every event with `@fires on-x - description. \`detail:{ ... }\``.
+If an event must cross shadow boundaries, set `composed: true`(and usually`bubbles: true`) deliberately and document it.
+
+- **Slots** are documented with `@slot name - description`; the default slot is
+  `@slot unnamed - ...`.
+- **CSS Shadow Parts** (`part="..."`) are documented with `@part name - description`
+  and are a theming contract consumers depend on.
+- **CSS custom properties** a component reads for theming are documented with
+  `@cssprop` and are also public API.
+
+---
+
+## 4. Styling and design tokens
+
+Components must style against **foundation tokens**, never hardcoded values.
+
+- SCSS files typically start with:
+
+  ```scss
+  @use '../../../common/scss/global.scss';
+  @use '@kyndryl-design-system/shidoka-foundation/scss/mixins/typography.scss';
+  ```
+
+- **Color:** `var(--kd-color-...)` (e.g., `--kd-color-background-button-primary-state-default`,
+  `--kd-color-text-forms-label-primary`). Never raw hex/rgb when a token exists.
+- **Spacing:** `var(--kd-spacing-...)` (e.g., `--kd-spacing-16`). Avoid magic px for
+  layout spacing.
+- **Typography:** `@include typography.type-...` mixins (e.g., `type-ui-02`) or
+  `--kd-font-weight-...` tokens and the `kd-type--*` utility classes in stories.
+- **Host display:** web components are `display: inline` by default — set
+  `:host { display: block; }` (or the intended value) explicitly.
+- **Dark mode / theming** is token-driven. Hardcoded colors break theming and are a
+  defect, not a nitpick.
+
+---
+
+## 5. Shared base patterns
+
+Reviewers must know these so they can flag re-implementations of solved problems.
+
+### FormMixin (`src/common/mixins/form-input.ts`)
+
+Form-associated controls extend `FormMixin(LitElement)` instead of re-implementing
+form plumbing. It provides:
+
+- `static formAssociated = true`, `delegatesFocus`, and `_internals = attachInternals()`.
+- Public `value`, `name`, `invalidText`, `warnText` properties.
+- `checkValidity()`, `reportValidity()`, and `validity` / `validationMessage` getters
+  that delegate to `ElementInternals`.
+- An abstract `_validate(interacted: boolean, report: boolean)` each control implements.
+- Automatic `setFormValue` on `value` change and `invalid`-event wiring.
+
+A new input component that hand-rolls validation or form association instead of using
+`FormMixin` is a red flag.
+
+### `@lit/context` for compound components
+
+Multi-part components (e.g., Table) share state via `@lit/context`
+(`createContext`, `@provide`, `@consume`, `ContextProvider`/`ContextConsumer`) rather
+than prop-drilling or querying across components. See `src/components/reusable/table/`.
+
+### Helpers (`src/common/helpers/`)
+
+Reuse shared helpers instead of duplicating: `debounce`, `createOptionsArray`
+(builds story option arrays from enums), `stringToReactHtml`, gridstack/swiper/
+flatpickr configs.
+
+### Lifecycle and performance
+
+- Add listeners in `connectedCallback` and **always remove them in
+  `disconnectedCallback`** (call `super` in both). Unremoved global listeners
+  (`window`/`document`) are memory leaks — a recurring, high-value review catch.
+- `debounce` resize/scroll handlers.
+- Prefer Lit directives (`ifDefined`, `classMap`, `styleMap`, `repeat`, `unsafeSVG`)
+  over manual DOM work.
+- Web components do **not** server-render; guard `window`/`document` access for SSR
+  consumers (Next.js, etc.).
+
+---
+
+## 6. Stories and documentation (required for every component)
+
+- One `<Name>.stories.js` per component with `title: 'Components/...'` and
+  `component: 'kyn-...'`.
+- **Controls for every public property.** Enum props use `argTypes` with options built
+  from `defs.ts` via `createOptionsArray` and labeled defaults.
+- Bind correctly in templates: attributes `attr=${...}`, booleans `?bool=${...}`,
+  properties `.prop=${...}`, events `@on-event=${action('on-event')}`.
+- Provide meaningful variants and (for rich components) a `Gallery` story showing all
+  kinds/sizes/states.
+- Compound components include subcomponents in the story so Storybook renders their
+  args tables.
+- **JSDoc is mandatory** on all props, slots, events, parts. After any doc/API change,
+  the author must run `npm run analyze` to regenerate `custom-elements.json` (Storybook
+  args derive from it). A public-API change with no manifest update is a defect.
+
+---
+
+## 7. Testing expectations
+
+- **Interaction & a11y tests** via Storybook `play` functions using `storybook/test`
+  (`expect`, `userEvent`, `waitFor`). Traverse shadow DOM explicitly
+  (`el.shadowRoot.querySelector(...)`) and `await el.updateComplete` before asserting.
+  Test files use the `*.test.stories.js` suffix and usually `tags: ['!autodocs']`.
+- **Accessibility** is validated by the Storybook a11y addon / test-runner (axe).
+  New interactive components should not regress a11y; keyboard operability and ARIA
+  are part of "done."
+- **Unit tests** for pure helpers use Vitest (`*.test.ts`).
+- **Visual regression** is handled by Chromatic in CI — the reviewer does not judge
+  pixels, but should confirm visually significant changes have story coverage so
+  Chromatic can catch them.
+
+---
+
+## 8. File structure and exports
+
+- Components live under `src/components/{ai,global,reusable}/<camelCase>/`.
+  - `ai` — AI-specific components.
+  - `global` — app-shell/global components (header, footer, localNav, uiShell).
+  - `reusable` — the general component library.
+- `index.ts` re-exports the class: `export { MyComponent } from './myComponent';`.
+- **New components must be exported from `src/index.ts`.** A new component that isn't
+  exported there is effectively unshipped — flag it.
+- `scripts/create-component.js` (`npm run create:component`) scaffolds all of this and
+  wires the exports; deviations from its output usually indicate a convention miss.
+
+---
+
+## 9. The "100% generic" rule
+
+From `CONTRIBUTING.md`: _"Everything in the design system should be 100% generic.
+Remember that these components could be used to build any application. Application
+concerns must be separated."_
+
+Flag anything that bakes application-specific assumptions into a component:
+hardcoded copy/labels that should be slots or props, business logic, app routes,
+product-specific data shapes, or coupling to a particular backend.
+
+---
+
+## 10. Governance: commits, versioning, releases
+
+- **Conventional Commits** (enforced by commitlint). Prefix drives the release:
+  - `fix:` → patch, `feat:` → minor, `BREAKING CHANGE:` footer or `!` → **major**.
+  - Other types (`chore`, `docs`, `refactor`, `test`, `build`, `ci`, `style`) don't
+    release on their own.
+- **DCO sign-off is required** on every commit (`Signed-off-by:`), enforced by the
+  `commit-msg` hook. Use `git commit -s` (or `git.alwaysSignOff` in the editor).
+- **semantic-release** publishes automatically on merge to `main` (stable) and
+  `beta`/`next` (prerelease); `N.x` branches are maintenance lines. Because release is
+  automatic, **all correctness must be verified at the PR stage.**
+- Branch naming: `feature/`, `bugfix/`, `hotfix/`.
+- Because this package is consumed by many applications, **commit type and breaking-
+  change declaration must match the actual change.** A breaking change shipped as a
+  `fix:` is a serious defect (see `30-breaking-change-detection.md`).
+
+---
+
+## 11. Lint/format/type gates (already enforced in CI)
+
+Don't re-run these, but know what they cover so you focus review effort elsewhere:
+
+- **ESLint:** `eslint:recommended`, `@typescript-eslint/recommended`,
+  `plugin:storybook/recommended`, `plugin:lit-a11y/recommended`. Notable: unused vars
+  warn (ignore `^_`), `lit-a11y/click-events-have-key-events` warns,
+  `import/extensions` enforces the `.js`-always/`.ts`-never rule.
+- **Prettier:** single quotes, semicolons, 2-space indent, `trailingComma: es5`,
+  `arrowParens: always`.
+- **lit-analyzer** (`ts-lit-plugin`, strict): template type-checking, attribute
+  binding correctness.
+
+Focus your human-grade attention on what these tools **cannot** see: API stability,
+accessibility semantics, token correctness, naming/consistency with sibling
+components, event/slot/part design, performance, and the "generic" rule.

--- a/review-kit/20-review-rubric.md
+++ b/review-kit/20-review-rubric.md
@@ -1,0 +1,146 @@
+# Shidoka PR Review Rubric
+
+The senior checklist. Apply it after reading `10-design-system-knowledge.md`. Map every
+finding to a severity (see `40-review-output-format.md`) and return results in that
+format. **Breaking-change detection (`30`) is mandatory on every review.**
+
+---
+
+## Review workflow
+
+Copy this checklist and work through it:
+
+```
+Review progress:
+- [ ] 1. Establish context (what changed, base branch, commit type)
+- [ ] 2. Run breaking-change detection (30-breaking-change-detection.md)
+- [ ] 3. Component-contract review (anatomy, props/state, events/slots/parts)
+- [ ] 4. Styling & tokens review
+- [ ] 5. Accessibility review
+- [ ] 6. Correctness, performance & lifecycle review
+- [ ] 7. Docs, stories, manifest & tests review
+- [ ] 8. Governance review (commit, versioning, exports, "generic" rule)
+- [ ] 9. Severity-rank findings, note what's done well, write verdict
+```
+
+### Step 1 — Establish context
+
+- Identify changed files and whether the change is a new component, an edit to an
+  existing one, a shared base/mixin change, a token change, or tooling.
+- Determine the base branch (`main`, `beta`, `next`, or `N.x`). If you cannot see it,
+  say so and scope confidence accordingly.
+- Note the Conventional Commit type(s) on the PR — you'll confirm they match the
+  actual change in Step 8.
+- **A change to a shared base (`FormMixin`, a context provider, a common helper, or a
+  foundation token) has blast radius across many components — review it with
+  proportionally more scrutiny.**
+
+### Step 2 — Breaking-change detection (mandatory)
+
+Follow `30-breaking-change-detection.md` in full. Produce the breaking-change report
+and, if anything broke, a prominent alert at the top of the review.
+
+---
+
+## Step 3 — Component-contract checklist
+
+- [ ] Tag is `kyn-<kebab>`; class is `PascalCase extends LitElement` (or a Shidoka mixin).
+- [ ] `HTMLElementTagNameMap` declaration present and correct.
+- [ ] `static override styles = unsafeCSS(...)` from a co-located `.scss` (`?inline`).
+- [ ] New class fields use the `accessor` keyword (standard decorators), not plain fields.
+- [ ] Public reactive data uses `@property({ type })`; **boolean props default to `false`**.
+- [ ] `reflect: true` used only where the attribute must mirror state; not by default.
+- [ ] Internal state uses `@state()`, underscore prefix, and `@internal` JSDoc. Same for
+      `@query*` and private methods.
+- [ ] Option sets are enums in a co-located `defs.ts`, exported for stories.
+- [ ] **Events** are `on-*` `CustomEvent`s with a `detail` object (`origEvent` when
+      wrapping native events); `composed`/`bubbles` are intentional and documented.
+- [ ] New props/events/slots/parts are **consistent with sibling components** (e.g.,
+      reuse `kind`, `size`, `disabled` naming and value vocabularies rather than
+      inventing new ones). Inconsistency with the rest of the system is a real defect.
+- [ ] No public API duplicates something a base class/mixin already provides.
+
+## Step 4 — Styling & tokens checklist
+
+- [ ] No hardcoded colors where a `--kd-color-*` token exists (defect, not nitpick —
+      it breaks theming/dark mode).
+- [ ] Spacing uses `--kd-spacing-*`; typography uses the `typography.type-*` mixins or
+      `--kd-font-weight-*` tokens.
+- [ ] `:host` display is set intentionally (components default to `inline`).
+- [ ] Styles are encapsulated; no leakage assumptions; theming via documented CSS parts
+      / custom properties.
+- [ ] SCSS uses the standard `@use` of `common/scss/global.scss` and foundation mixins.
+
+## Step 5 — Accessibility checklist
+
+- [ ] Interactive elements are keyboard-operable (Enter/Space/Arrow as appropriate) and
+      focusable; focus is visible and managed (focus trap/return for overlays).
+- [ ] Correct semantics/roles; `aria-*` used correctly (`aria-label`, `aria-expanded`,
+      `aria-controls`, `aria-current`, etc.); no redundant/incorrect roles.
+- [ ] Click handlers on non-button elements also handle keyboard (the
+      `lit-a11y/click-events-have-key-events` rule warns — treat as must-fix for new code).
+- [ ] Slotted content and shadow DOM don't break the accessibility tree or label
+      associations; `delegatesFocus` used where appropriate.
+- [ ] Color is not the only signal; contrast comes from tokens; motion is reasonable.
+- [ ] Icon-only controls have an accessible name (`description`/`aria-label`).
+
+## Step 6 — Correctness, performance & lifecycle checklist
+
+- [ ] Every listener added in `connectedCallback` is removed in `disconnectedCallback`;
+      both call `super`. (Global `window`/`document` listeners are the usual leak.)
+- [ ] Resize/scroll/input handlers are debounced where appropriate.
+- [ ] No unnecessary re-renders or `requestUpdate` loops; reactive properties drive
+      updates; `updated`/`willUpdate` guarded by `changedProps.has(...)`.
+- [ ] Lit directives used instead of manual DOM manipulation; `unsafeHTML`/`unsafeSVG`
+      only on trusted content (XSS risk otherwise).
+- [ ] SSR-safety: `window`/`document` access guarded for downstream SSR consumers.
+- [ ] Edge cases handled: empty/long slot content, disabled state, RTL if relevant,
+      rapid interaction, null/undefined inputs.
+
+## Step 7 — Docs, stories, manifest & tests checklist
+
+- [ ] JSDoc present on all public props, slots, events, parts.
+- [ ] `custom-elements.json` regenerated (`npm run analyze`) and committed when the
+      public API or docs changed. Manifest drift = defect.
+- [ ] Stories exist with controls for every public property; enum controls built from
+      `defs.ts`; meaningful variants (and a Gallery for rich components).
+- [ ] Interaction/a11y `play` tests cover new behavior; shadow DOM traversed correctly;
+      `await updateComplete` before assertions.
+- [ ] Visually significant changes have story coverage so Chromatic can catch regressions.
+- [ ] PR checklist items in `.github/pull_request_template.md` are satisfied.
+
+## Step 8 — Governance checklist
+
+- [ ] **Commit type matches the change** and the breaking-change declaration is correct:
+      a removed/renamed public API must ship as a `feat!`/`BREAKING CHANGE:`, never a
+      bare `fix:`/`feat:`.
+- [ ] **Commit type isn't accidentally under-classified:** a user-facing fix/behavior
+      change shipped as a non-releasing `chore`/`refactor`/`style` skips the release and
+      changelog. This is often an intentional maintainer choice — raise it as a
+      _confirmation_, not a blocking defect, and accept a stated rationale.
+- [ ] Commits use Conventional Commit format and include DCO `Signed-off-by:`.
+- [ ] New components are exported from `src/index.ts`.
+- [ ] The "100% generic" rule holds — no application-specific concerns leaked into a
+      component.
+- [ ] Change is scoped; unrelated refactors/format churn aren't smuggled into the PR.
+
+---
+
+## Calibration: what is and isn't a senior-grade finding
+
+- **Treat as defects (not nitpicks):** undeclared breaking changes; hardcoded colors;
+  missing listener cleanup; missing accessible names/keyboard support; new public API
+  inconsistent with the system; missing manifest update on API change; application
+  concerns in a generic component; `fix:` on a breaking change.
+- **Treat as suggestions/judgment:** internal structure/readability, naming of private
+  helpers, optional performance micro-optimizations, test thoroughness beyond the new
+  behavior, alternative API designs (present trade-offs, let the human decide).
+- **Treat as confirmations (surface, don't block):** commit-type/release choices that may
+  be intentional (e.g., a user-facing change deliberately held as a non-releasing `chore`)
+  and other deliberate maintainer decisions. Raise them, accept stated intent, and don't
+  let them force a "Request changes" verdict.
+- **Out of scope / defer:** pixel-level visual fidelity (Chromatic + humans), product
+  decisions, and anything requiring context the diff doesn't contain — say so explicitly.
+
+Lead with the highest-severity items. Never let nitpicks bury a breaking change or an
+accessibility blocker.

--- a/review-kit/20-review-rubric.md
+++ b/review-kit/20-review-rubric.md
@@ -26,6 +26,10 @@ Review progress:
 
 ### Step 1 — Establish context
 
+- **Resolve the review target.** If a PR id/URL was provided, review that PR
+  (`gh pr diff <id>`, compared to its base branch). If none was specified, default to the
+  **current branch vs `main`** (`git diff --merge-base origin/main HEAD`) and note any
+  uncommitted working-tree changes separately.
 - Identify changed files and whether the change is a new component, an edit to an
   existing one, a shared base/mixin change, a token change, or tooling.
 - Determine the base branch (`main`, `beta`, `next`, or `N.x`). If you cannot see it,

--- a/review-kit/20-review-rubric.md
+++ b/review-kit/20-review-rubric.md
@@ -21,6 +21,7 @@ Review progress:
 - [ ] 7. Docs, stories, manifest & tests review
 - [ ] 8. Governance review (commit, versioning, exports, "generic" rule)
 - [ ] 9. Severity-rank findings, note what's done well, write verdict
+- [ ] 10. Emit the copy-paste PR description (see 40-review-output-format.md)
 ```
 
 ### Step 1 — Establish context

--- a/review-kit/30-breaking-change-detection.md
+++ b/review-kit/30-breaking-change-detection.md
@@ -1,0 +1,139 @@
+# Breaking-Change Detection
+
+**Run this on every review.** Shidoka ships to many downstream applications via
+semantic-release, so a breaking change that isn't declared as one will auto-publish and
+break consumers. Detecting these and **alerting the author** is the highest-value job of
+this reviewer.
+
+A change is **breaking (MAJOR)** if it removes or alters any part of the public API that
+a consumer could depend on. The public API surface is: package exports, custom-element
+tag names, attributes/properties, custom events, slots, CSS shadow parts, themeable CSS
+custom properties, and the documented behavior/defaults of all of the above.
+
+---
+
+## Workflow
+
+```
+Breaking-change scan:
+- [ ] A. Diff the public API surface against the base branch
+- [ ] B. Classify each change (none / patch / minor / MAJOR)
+- [ ] C. Cross-check the declared commit type / PR semver intent
+- [ ] D. Emit a Breaking-Change Report (and a top-of-review alert if MAJOR)
+```
+
+### A. Diff the public API surface
+
+Prefer real diffs over eyeballing. If you have shell access, compute them against the
+PR's base branch (substitute `origin/main` with `origin/beta`, `origin/next`, or the
+`N.x` line as appropriate):
+
+```bash
+# Make sure the base is available, then diff against the merge-base.
+git fetch origin
+
+# 1. Package export surface — removed/renamed exports are breaking.
+git diff --merge-base origin/main -- src/index.ts
+
+# 2. Option/enum vocabularies — removed/renamed enum values are breaking.
+git diff --merge-base origin/main -- 'src/**/defs.ts'
+
+# 3. The authoritative public-API manifest (attributes, props, events, slots,
+#    CSS parts, CSS custom properties for every component).
+git diff --merge-base origin/main -- custom-elements.json
+
+# 4. Component sources — focus on decorators, JSDoc surface tags, and event names.
+git diff --merge-base origin/main -- 'src/components/**/*.ts'
+```
+
+If you cannot run git (e.g., you were handed only a patch or file list), inspect the
+provided diff for the same signals and state that detection was limited to the supplied
+context.
+
+`custom-elements.json` is the richest signal: a removed entry under a component's
+`attributes`, `members`, `events`, `slots`, `cssParts`, or `cssProperties` is almost
+always breaking. **Note also the inverse:** if a component's source clearly changed its
+public API but `custom-elements.json` did **not** change, the author forgot to run
+`npm run analyze` — flag the manifest drift.
+
+**Surface vs. behavior.** The diffs above catch _structural_ breaks (removed/renamed
+API). They will **not** show **behavioral** changes to existing props, events, or
+defaults — e.g., a prop that now interacts differently with another prop, a changed
+default, or reworked event-firing conditions. Always read the changed `render`,
+event-handler, and lifecycle logic and reason about runtime behavior, not just the
+surface diff.
+
+### B. Classify each change
+
+| Change                                                                              | Severity                                                                              |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Removed/renamed export from `src/index.ts`                                          | **MAJOR**                                                                             |
+| Removed/renamed custom element tag (`kyn-*`)                                        | **MAJOR**                                                                             |
+| Removed/renamed `@property` (attribute/prop)                                        | **MAJOR**                                                                             |
+| Changed a property's type in an incompatible way, or narrowed accepted values       | **MAJOR**                                                                             |
+| Removed/renamed enum value used by a public prop (e.g., a `kind`)                   | **MAJOR**                                                                             |
+| Renamed/removed a slot, CSS part, or themeable CSS custom property                  | **MAJOR**                                                                             |
+| Renamed/removed a custom event, or changed its `detail` shape                       | **MAJOR**                                                                             |
+| Changed a default value or default behavior consumers rely on                       | **MAJOR** (usually)                                                                   |
+| Changed runtime behavior/interaction of an existing prop, no surface change         | **PATCH** (`fix`) if backward compatible; **MAJOR** if consumers rely on old behavior |
+| DOM structure change that breaks documented `part`/selector targeting               | **MAJOR**                                                                             |
+| Added a **new required** property/attribute (no safe default)                       | **MAJOR**                                                                             |
+| Added a new optional property/event/slot/part (backward compatible)                 | **MINOR** (`feat`)                                                                    |
+| Bug fix with no public-API change                                                   | **PATCH** (`fix`)                                                                     |
+| Internal-only change (underscore/`@internal` members, private methods, build, docs) | none / non-releasing                                                                  |
+
+Renames are **two** events (a removal + an addition) — treat the removal as breaking
+even when an alias is added, unless the old name is kept and deprecated.
+
+### C. Cross-check the declared intent
+
+- A **MAJOR** change must ship as `feat!:` / `fix!:` (or include a `BREAKING CHANGE:`
+  footer). A breaking change declared as a bare `fix:` or `feat:` is a
+  **critical defect** — it will mis-version the release.
+- A **new feature** (new optional API) should be a `feat:` (minor), not a `fix:`.
+- Internal-only changes shouldn't claim `feat`/`fix` that trigger an unintended release.
+- **The inverse is a _confirm_, not a hard defect:** a user-facing bug fix or behavior
+  change shipped as a non-releasing type (`chore`, `refactor`, `style`) won't release or
+  appear in the changelog. This is **often an intentional maintainer choice** (batching,
+  holding for a coordinated release, or a not-yet-consumed component). Surface it as a
+  confirmation — "non-releasing type for a user-facing change; intentional?" — and accept
+  a stated rationale. If it was unintentional, a behavioral fix should be `fix:` (patch).
+- **Severity contrast (important):** _missing a release_ (a fix shipped as `chore`) is
+  recoverable and often deliberate → **Confirm, non-blocking**. _Breaking consumers_ (a
+  breaking change shipped without a major bump) actively corrupts semver downstream →
+  **Critical, blocking**. Hold the hard line only on the latter.
+- If the breaking change is intentional, confirm the PR documents the migration path
+  (what consumers must change) and, where feasible, that a deprecation/alias was
+  considered before outright removal.
+
+### D. Emit the Breaking-Change Report
+
+Always include this section in the review, even when nothing broke.
+
+**When nothing breaks:**
+
+```
+### Breaking-change scan
+No public-API breaking changes detected (export surface, custom-elements.json,
+enums, events/slots/parts unchanged or only additive). Suggested semver: MINOR
+(new optional `<x>` property) / PATCH / none.
+```
+
+**When something breaks — lead the review with this alert:**
+
+```
+> ## BREAKING CHANGE DETECTED
+> This PR changes the public API in ways that will break downstream consumers.
+>
+> | What changed | File:line | Impact | Required action |
+> |--------------|-----------|--------|-----------------|
+> | Removed `kyn-button` `kind="content"` value | src/components/reusable/button/defs.ts:19 | Consumers using `kind="content"` break | Restore value, or document removal + bump MAJOR |
+> | Renamed event `on-select` → `on-change` | src/components/reusable/dropdown/dropdown.ts:120 | Listeners on `on-select` stop firing | Keep `on-select` as deprecated alias, or bump MAJOR |
+>
+> Declared commit type: `feat:` (minor). **Required:** `feat!:` / `BREAKING CHANGE:` (major),
+> or revise the change to remain backward compatible. The author must confirm this is intentional.
+```
+
+Be precise about _what_ broke and _why it matters to a consumer_, and give the author a
+concrete choice: make it backward compatible (preferred — alias + deprecate) or declare
+it as a major with a migration note.

--- a/review-kit/40-review-output-format.md
+++ b/review-kit/40-review-output-format.md
@@ -15,6 +15,22 @@ alert so the most important information is never buried.
 | **Nit**      | Optional polish                                                          | Naming of private helpers, internal readability, micro-optimizations                                                                                                       |
 | **Praise**   | Done well                                                                | Correct pattern reuse, thorough tests, clean API design                                                                                                                    |
 
+## Priority labels (P0–P3)
+
+Tag every actionable finding with a priority so it reads as a discrete, triageable item.
+The labels map onto the severity levels above:
+
+| Priority | Maps to severity   | Meaning                                                                                                                                         | Blocks merge?      |
+| -------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| **P0**   | BREAKING, Critical | Will break consumers or ship a defect: undeclared/mis-declared API break, a11y blocker, memory leak, XSS, broken form association.              | **Yes**            |
+| **P1**   | Major              | Should fix before merge: hardcoded color/token misuse, missing keyboard support, API inconsistent with the system, manifest drift, app concern. | Strongly preferred |
+| **P2**   | Minor              | Worth fixing, not blocking: missing story control, incomplete JSDoc, thin test coverage of new behavior.                                        | No                 |
+| **P3**   | Nit                | Optional polish: naming of private helpers, internal readability, micro-optimizations.                                                          | No                 |
+
+**Confirm** and **Praise** are **not** P-rated — a Confirm is a question for the author
+(surface it, don't block) and Praise is positive reinforcement. Undeclared **BREAKING**
+items are P0 and must **also** appear in the top-of-review alert.
+
 ## Template
 
 ````markdown
@@ -53,29 +69,32 @@ _Status: **Pass** none found · **Warn** minor/suggestions · **Fail** critical/
 
 ### Findings
 
-#### Critical
+Emit **one standalone block per actionable item**, tagged with its priority (`P0`–`P3`),
+ordered P0 → P3, so each item can be posted or pasted as an individual review comment.
+Never bundle multiple issues into one block. If a priority level has no items, write "None."
 
-- **[Critical] <title>** — `path/to/file.ts:LINE`
-  - Problem: <what's wrong>
-  - Why it matters: <impact for a shared design system>
-  - Fix:
-    ```ts
-    <concrete corrected snippet>
-    ```
+#### [P0] <title> — `path/to/file.ts:LINE`
 
-#### Major
+- **Problem:** <what's wrong>
+- **Why it matters:** <impact for a shared design system / downstream consumers>
+- **Fix:**
+  ```ts
+  <concrete corrected snippet>
+  ```
 
-- **[Major] <title>** — `path/to/file.ts:LINE` — <problem, why, fix>
+#### [P1] <title> — `path/to/file.ts:LINE`
 
-#### Minor
+- **Problem / why / fix:** <what's wrong, why it matters, and the concrete fix>
 
-- **[Minor] <title>** — `path/to/file.ts:LINE` — <problem + suggested fix>
+#### [P2] <title> — `path/to/file.ts:LINE`
 
-#### Nits
+- <problem + suggested fix>
 
-- `path/to/file.ts:LINE` — <optional polish>
+#### [P3] <title> — `path/to/file.ts:LINE`
 
-#### Confirmations needed (not blocking)
+- <optional polish>
+
+### Confirmations (not blocking, not P-rated)
 
 - **[Confirm] <title>** — <what to verify with the author, e.g. "user-facing fix shipped as a non-releasing `chore` — intentional hold/batch, or should it be `fix:`?">
 
@@ -96,7 +115,9 @@ evidences; leave author-only items (local test run, Figma link) unchecked.
 ```markdown
 ## Summary
 
-<concise description of what changed and why>
+- <most important change, in one scannable bullet>
+- <next change and/or its purpose>
+- <…3–6 short bullets, one idea each; no single-paragraph summary>
 
 ## ADO Story or GitHub Issue Link
 
@@ -141,8 +162,9 @@ evidences; leave author-only items (local test run, Figma link) unchecked.
 - Every finding cites **`file:line`** (or a range) and names the rule from
   `10`/`20` it relates to.
 - Prefer a **concrete fix** (a snippet or a precise instruction) over a vague concern.
-- Order findings by severity, highest first. If there are no Critical/Breaking items,
-  say so explicitly.
+- Order findings by **priority (P0 → P3)**, highest first, and emit **one standalone block
+  per item** so each maps cleanly to a single review comment — never bundle issues. If there
+  are no P0 (Critical/BREAKING) items, say so explicitly.
 - Keep judgment calls in their own section and defer the final decision to the human —
   do not block a PR on taste.
 - **Confirm** items are not defects: surface them, but they do **not** drive a "Request
@@ -161,8 +183,11 @@ author can paste straight into the PR.
   it is the source of truth); otherwise use the embedded template above. Keep every heading.
 - **Wrap it in a ` ```markdown ` fenced block** so it renders with a copy button and pastes
   as raw markdown.
-- **Summary / Notes / Testing Instructions:** fill from your review — concise, specific,
-  derived from the actual diff. Notes should bullet the substantive changes.
+- **Summary:** render as a **bulleted list (3–6 short, scannable bullets), never a single
+  paragraph** — lead with the most important change, one idea per bullet. Do this even when
+  the repo template shows a prose placeholder; the reader should be able to skim it at a glance.
+- **Notes / Testing Instructions:** fill from your review — concise, specific, derived from
+  the actual diff. Notes should bullet the substantive changes.
 - **To Do:** list this review's unresolved findings (e.g., "run `analyze`", "add a
   regression test"); use "None" if clean.
 - **Checklist — tick honestly from evidence only.** Check items the diff/repo objectively

--- a/review-kit/40-review-output-format.md
+++ b/review-kit/40-review-output-format.md
@@ -1,0 +1,105 @@
+# Review Output Format
+
+Return every review in this structure. Lead with the verdict and any breaking-change
+alert so the most important information is never buried.
+
+## Severity levels
+
+| Level        | Meaning                                                                  | Examples                                                                                                                                                                   |
+| ------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **BREAKING** | Public-API break that will break consumers if shipped as-is              | Removed prop/event/slot/part, removed export, changed default behavior                                                                                                     |
+| **Critical** | Must fix before merge                                                    | Mis-declared breaking change, a11y blocker, memory leak, XSS via `unsafeHTML`, broken form association                                                                     |
+| **Major**    | Should fix before merge                                                  | Hardcoded color/token misuse, missing keyboard support, public API inconsistent with the system, missing manifest update on API change, app concern in a generic component |
+| **Confirm**  | Maintainer judgment — surface, **don't block**. Not a defect on its own. | Non-releasing commit type that may be intentional, a deliberate API/behavior decision, an intentional hold/batch                                                           |
+| **Minor**    | Worth fixing; not blocking                                               | Missing story control, incomplete JSDoc, weak test coverage of new behavior                                                                                                |
+| **Nit**      | Optional polish                                                          | Naming of private helpers, internal readability, micro-optimizations                                                                                                       |
+| **Praise**   | Done well                                                                | Correct pattern reuse, thorough tests, clean API design                                                                                                                    |
+
+## Template
+
+````markdown
+## Shidoka PR Review — <component / area>
+
+**Verdict:** Approve | Approve with comments | Request changes
+**Suggested semver:** none | patch | minor | MAJOR
+**Confidence:** high | medium | low — <note any missing context, e.g. base branch or visual output not available>
+
+> ## BREAKING CHANGE DETECTED <!-- include this block only if applicable -->
+>
+> <table from 30-breaking-change-detection.md: what changed, file:line, impact, required action>
+> Declared commit type: `<type>`. Required: `<type!>` / `BREAKING CHANGE:` or make backward compatible.
+
+### Summary
+
+<2–4 sentences: what the PR does and the overall assessment.>
+
+### Breaking-change scan
+
+<Always present. The "nothing breaks" or the detailed report from `30`.>
+
+### Review coverage
+
+| Area                                                          | Status                 | Notes |
+| ------------------------------------------------------------- | ---------------------- | ----- |
+| Breaking-change scan                                          | Pass/Warn/Fail/Confirm |       |
+| Component contract (anatomy, props/state, events/slots/parts) | Pass/Warn/Fail/N/A     |       |
+| Styling & design tokens                                       | …                      |       |
+| Accessibility                                                 | …                      |       |
+| Correctness, performance & lifecycle                          | …                      |       |
+| Docs, stories, manifest & tests                               | …                      |       |
+| Governance (commit type, versioning, exports, generic rule)   | …                      |       |
+
+_Status: **Pass** none found · **Warn** minor/suggestions · **Fail** critical/major defect · **Confirm** maintainer judgment to verify · **N/A** not touched by this diff. Every area must appear, even if N/A._
+
+### Findings
+
+#### Critical
+
+- **[Critical] <title>** — `path/to/file.ts:LINE`
+  - Problem: <what's wrong>
+  - Why it matters: <impact for a shared design system>
+  - Fix:
+    ```ts
+    <concrete corrected snippet>
+    ```
+
+#### Major
+
+- **[Major] <title>** — `path/to/file.ts:LINE` — <problem, why, fix>
+
+#### Minor
+
+- **[Minor] <title>** — `path/to/file.ts:LINE` — <problem + suggested fix>
+
+#### Nits
+
+- `path/to/file.ts:LINE` — <optional polish>
+
+#### Confirmations needed (not blocking)
+
+- **[Confirm] <title>** — <what to verify with the author, e.g. "user-facing fix shipped as a non-releasing `chore` — intentional hold/batch, or should it be `fix:`?">
+
+### Done well
+
+- <1–3 genuine positives so the author learns the system.>
+
+### Open questions / judgment calls (for the human reviewer)
+
+- <Architectural or product trade-offs you are deliberately not deciding, with options.>
+````
+
+## Rules for findings
+
+- Every finding cites **`file:line`** (or a range) and names the rule from
+  `10`/`20` it relates to.
+- Prefer a **concrete fix** (a snippet or a precise instruction) over a vague concern.
+- Order findings by severity, highest first. If there are no Critical/Breaking items,
+  say so explicitly.
+- Keep judgment calls in their own section and defer the final decision to the human —
+  do not block a PR on taste.
+- **Confirm** items are not defects: surface them, but they do **not** drive a "Request
+  changes" verdict on their own. Reserve "Request changes" for Critical/BREAKING/Major
+  defects; if the only open items are confirmations, the verdict is "Approve with comments."
+- **Respect stated maintainer intent.** If the author has confirmed a choice (e.g., an
+  intentional non-releasing commit type), accept it and don't re-flag it.
+- If the diff was incomplete, state exactly what you could and couldn't assess.

--- a/review-kit/40-review-output-format.md
+++ b/review-kit/40-review-output-format.md
@@ -86,6 +86,54 @@ _Status: **Pass** none found · **Warn** minor/suggestions · **Fail** critical/
 ### Open questions / judgment calls (for the human reviewer)
 
 - <Architectural or product trade-offs you are deliberately not deciding, with options.>
+
+### Proposed PR description (copy-paste)
+
+Filled from this review; mirrors `.github/pull_request_template.md`. Wrapped in a fenced
+block so it pastes as raw markdown. Tick only checklist items the diff/repo objectively
+evidences; leave author-only items (local test run, Figma link) unchecked.
+
+```markdown
+## Summary
+
+<concise description of what changed and why>
+
+## ADO Story or GitHub Issue Link
+
+<link if referenced in the PR/diff, else N/A>
+
+## Figma Link
+
+<link if known, else N/A>
+
+## Notes
+
+- <substantive change note derived from the diff>
+- <...>
+
+## To Do
+
+- <unresolved follow-ups this review surfaced, else "None">
+
+## Checklist
+
+- [ ] Used Conventional Commit messages as outlined in the contributing guide.
+  - [ ] Noted breaking changes (if any).
+- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
+  - [ ] Ran the `analyze` command to update Storybook docs.
+- [ ] Added/updated Stories with controls to cover all variants.
+- [ ] Ran `test` locally to address any failures.
+- [ ] Added/updated the Figma link for the Story's Design tab.
+- [ ] Added any new component exports to the src/index.ts file
+
+## Testing Instructions
+
+<concrete steps for a reviewer/tester to validate the change>
+
+## Screenshots
+
+(if any)
+```
 ````
 
 ## Rules for findings
@@ -103,3 +151,24 @@ _Status: **Pass** none found · **Warn** minor/suggestions · **Fail** critical/
 - **Respect stated maintainer intent.** If the author has confirmed a choice (e.g., an
   intentional non-releasing commit type), accept it and don't re-flag it.
 - If the diff was incomplete, state exactly what you could and couldn't assess.
+
+## PR description rules
+
+Every review ends with the **Proposed PR description** section — a copy-paste block the
+author can paste straight into the PR.
+
+- **Structure:** use the repo's `.github/pull_request_template.md` when present (read it —
+  it is the source of truth); otherwise use the embedded template above. Keep every heading.
+- **Wrap it in a ` ```markdown ` fenced block** so it renders with a copy button and pastes
+  as raw markdown.
+- **Summary / Notes / Testing Instructions:** fill from your review — concise, specific,
+  derived from the actual diff. Notes should bullet the substantive changes.
+- **To Do:** list this review's unresolved findings (e.g., "run `analyze`", "add a
+  regression test"); use "None" if clean.
+- **Checklist — tick honestly from evidence only.** Check items the diff/repo objectively
+  shows: JSDoc present, `custom-elements.json`/`analyze` updated, stories with controls
+  added, exports added to `src/index.ts`, Conventional Commits used, breaking changes noted.
+  Leave **author-only / process** items unchecked for the human — never tick "Ran `test`
+  locally" or "Added the Figma link," which you cannot verify.
+- **Links (ADO/GitHub issue, Figma):** fill only if referenced in the PR/diff; otherwise
+  leave `N/A` or `<add link>`. Never invent a link.

--- a/review-kit/README.md
+++ b/review-kit/README.md
@@ -1,0 +1,72 @@
+# Shidoka PR Review Kit
+
+A **model- and platform-agnostic** knowledge base + rubric that lets any capable AI
+assistant (Cursor, GitHub Copilot, Claude, or a raw API call) perform
+**Lead/Senior-grade pull-request reviews** of the Shidoka design system
+(`shidoka-applications`, `shidoka-foundation`, and siblings).
+
+This folder is the **single source of truth**. The platform adapters elsewhere in
+the repo are thin pointers that load these files and nothing else.
+
+## What's in here
+
+| File                              | Purpose                                                                                        |
+| --------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `00-reviewer-system-prompt.md`    | The reviewer persona. Paste into any chat/API/CI as the system prompt.                         |
+| `10-design-system-knowledge.md`   | The full authoring contract: component anatomy, tokens, mixins, events, structure, governance. |
+| `20-review-rubric.md`             | The senior review checklist, severity levels, and step-by-step review workflow.                |
+| `30-breaking-change-detection.md` | How to automatically detect public-API breaks and alert the author.                            |
+| `40-review-output-format.md`      | The exact structure every review must be returned in.                                          |
+
+## Ground truth that stays current automatically
+
+You do **not** need to hand-maintain a catalog of every component. Two artifacts the
+repo already generates are authoritative and always up to date:
+
+- **`custom-elements.json`** (repo root) — a machine-readable manifest of every
+  component's public API (attributes, properties, slots, events, CSS parts, CSS
+  custom properties). This is the canonical "what exists" reference and the basis
+  for breaking-change detection.
+- **`@kyndryl-design-system/shidoka-foundation`** (`node_modules/.../css/*.css`,
+  `scss/`) — the design tokens, typography mixins, and reset that components must
+  style against.
+
+The rubric tells the reviewer to consult these directly rather than trusting a
+stale, copied list.
+
+## How each platform loads this kit
+
+| Platform                 | Adapter (entry point)                       | Mechanism                                                              |
+| ------------------------ | ------------------------------------------- | ---------------------------------------------------------------------- |
+| **Cursor**               | `.cursor/skills/shidoka-pr-review/SKILL.md` | Invoked when you ask to review a PR/changes against Shidoka standards. |
+| **GitHub Copilot**       | `.github/copilot-instructions.md`           | Auto-loaded into Copilot Chat for this repo.                           |
+| **Claude (Code / API)**  | `CLAUDE.md`                                 | Auto-loaded by Claude Code; also usable as a Claude Skill.             |
+| **Any model / CI / API** | `review-kit/00-reviewer-system-prompt.md`   | Use as the system prompt; attach the other files as context.           |
+
+## Using it from any model or CI pipeline
+
+1. Send `00-reviewer-system-prompt.md` as the system prompt.
+2. Attach `10`, `20`, `30`, and `40` as context (or let the agent read them).
+3. Provide the diff. Good options, in order of richness:
+   - `git diff --merge-base origin/main` (or the PR's base branch), or
+   - the PR URL / patch, or
+   - the changed files.
+4. The model returns a review in the format from `40-review-output-format.md`,
+   including a prominent breaking-change alert when applicable.
+
+## Exporting to another repo
+
+This folder is self-contained. To reuse it in a consumer app or another library:
+
+1. Copy the `review-kit/` folder into the target repo.
+2. Copy whichever adapter(s) you need (`.cursor/skills/...`, `.github/copilot-instructions.md`, `CLAUDE.md`).
+3. If the target repo _consumes_ Shidoka rather than _builds_ it, adjust the persona
+   focus in `00-reviewer-system-prompt.md` from "authoring" to "correct usage"
+   (the rubric notes which checks apply to each case).
+
+## Maintenance
+
+- Keep this kit accurate when authoring conventions change. The conventions, not the
+  component list, are what need hand-maintenance.
+- Re-read `10-design-system-knowledge.md` after major refactors to the base classes
+  (`FormMixin`, context providers) or token system.


### PR DESCRIPTION
## Summary

- Add a canonical, platform-agnostic `review-kit/` for the Shidoka design system — reviewer persona, authoring contract, senior rubric, mandatory breaking-change detection, and structured output format.
- Wire four thin adapters to that single source of truth: Cursor skill, GitHub Copilot instructions, `CLAUDE.md`, and a new `.cursor/BUGBOT.md` for always-on PR review.
- Make reviews triage-friendly: findings emit one standalone block per item tagged **P0–P3**, and the generated PR-description Summary renders as bullets (not a paragraph).
- Scope the `.cursor` gitignore to share team `skills/`, `rules/`, and `BUGBOT.md` while keeping secret-bearing/local files (e.g. `mcp.json`) out of git.
- Pin `esbuild` via `overrides`.
- Tooling/docs only — nothing is published in `dist/`.

## ADO Story or GitHub Issue Link

N/A

## Figma Link

N/A

## Notes

- `review-kit/`: portable reviewer system prompt, full authoring contract, senior rubric, mandatory breaking-change detection, structured output + copy-paste PR description.
- Adapters: `.cursor/skills/shidoka-pr-review/SKILL.md`, `.github/copilot-instructions.md`, `CLAUDE.md` — all point at the canonical kit.
- `.gitignore`: share `.cursor/skills/` and `.cursor/rules/`; ignore everything else under `.cursor/` (e.g. `mcp.json`).
- `package.json`: add `overrides: { esbuild }` (dev-only; does not affect consumers).

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide. _(2 of 4 commits use `fix:` for tooling — reword to `chore`/`docs`)_
  - [x] Noted breaking changes (if any). _(none)_
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc. _(N/A — no components)_
  - [ ] Ran the `analyze` command to update Storybook docs. _(N/A)_
- [ ] Added/updated Stories with controls to cover all variants. _(N/A)_
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab. _(N/A)_
- [ ] Added any new component exports to the src/index.ts file _(N/A — no components)_

## Screenshots

(if any)