### PR TITLE
fix(statusbtn): updated height to 24px

### DIFF
--- a/src/components/reusable/card/card.scss
+++ b/src/components/reusable/card/card.scss
@@ -58,7 +58,7 @@
     cursor: default;
 
     &.compact {
-      padding: 4px;
+      padding: 8px;
     }
 
     &.ai-highlight {

--- a/src/components/reusable/statusButton/statusButton.scss
+++ b/src/components/reusable/statusButton/statusButton.scss
@@ -9,7 +9,7 @@
 .status-btn {
   @include typography.type-ui-03;
   display: flex;
-  height: 26px;
+  height: 24px;
   align-items: center;
   justify-content: space-around;
   border: 0.5px solid transparent;


### PR DESCRIPTION
## Summary

Updated height from 26px -> 24px

## As reported on MS Team channel

[MSTeam](https://teams.microsoft.com/l/message/19:m15yXA3kC7fl9TvnIML-6DxhfDtwyoLJMu0nVAeddXQ1@thread.tacv2/1781703363510?tenantId=f260df36-bc43-424c-8f44-c85226657b01&groupId=6097bcb7-eb77-4588-9226-1430b9c803ab&parentMessageId=1781703363510&teamName=Shidoka%20Design%20System&channelName=General&createdTime=1781703363510)

## Figma Link

Link here (if applicable).

## Notes

- Detailed change notes
- can go here

## To Do

- Anything else
- left to do

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


