### PR TITLE
fix(progress): updated hidelabel

### DIFF
--- a/src/components/reusable/progressBar/progressBar.scss
+++ b/src/components/reusable/progressBar/progressBar.scss
@@ -29,16 +29,16 @@ $progress-bar-radius: 4px;
     align-items: center;
     padding: 0;
     margin: 0;
-
-    &.sr-only {
-      @include visibility.sr-only;
-    }
   }
 
   &__label {
     display: flex;
     align-items: center;
     margin: 0;
+
+    &.sr-only {
+      @include visibility.sr-only;
+    }
   }
 
   &__helper-text {
@@ -59,6 +59,7 @@ $progress-bar-radius: 4px;
     align-items: center;
     padding-right: 2px;
     line-height: 1;
+    margin-left: auto;
 
     .success-icon {
       svg {

--- a/src/components/reusable/progressBar/progressBar.ts
+++ b/src/components/reusable/progressBar/progressBar.ts
@@ -164,10 +164,13 @@ export class ProgressBar extends LitElement {
     currentValue: number | null
   ) {
     return html`
-      <div
-        class="progress-bar__upper-container${this.hideLabel ? ' sr-only' : ''}"
-      >
-        <label class="progress-bar__label label-text" for=${this.progressBarId}>
+      <div class="progress-bar__upper-container">
+        <label
+          class="progress-bar__label label-text ${this.hideLabel
+            ? ' sr-only'
+            : ''}"
+          for=${this.progressBarId}
+        >
           <span>${this.label}</span>
           <slot name="unnamed"></slot>
         </label>


### PR DESCRIPTION
## Summary

sr-only css getting applied to parent container instead of label which hides % value also when hide label true.

## GitHub Issue Link

https://github.com/kyndryl-design-system/shidoka-applications/issues/905


## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file



## ScreenRecording

https://deploy-preview-906--shidoka-applications.netlify.app/?path=/story/components-feedback-status-progress-bar--default&args=hideLabel:!true
