### PR TITLE
fix(tablecell) : added css for progress bar inside tabel cell

### DIFF
--- a/src/components/reusable/table/table-cell.scss
+++ b/src/components/reusable/table/table-cell.scss
@@ -17,13 +17,21 @@
 
 .slot-wrapper {
   display: inline-block;
+  width: 100%;
+  min-width: 0;
   max-width: 100%;
 }
 
-.slot-wrapper::slotted(*) {
+.slot-wrapper slot::slotted(*) {
   display: flex;
   min-width: 0;
   flex-shrink: 1;
+}
+
+.slot-wrapper slot::slotted(kyn-progress-bar) {
+  display: block;
+  width: 100%;
+  max-width: 100%;
 }
 
 :host([align='left']) {


### PR DESCRIPTION
## Summary

Progress bar was not taking complete width inside the table cell due to display: inline-block styling.

## GitHub Issue Link

https://github.com/kyndryl-design-system/shidoka-applications/issues/908

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## Screenshots

**Before fix** 

<img width="1013" height="505" alt="Screenshot 2026-07-09 at 11 33 47 AM" src="https://github.com/user-attachments/assets/2bf4b572-86dc-4ad2-bc39-7b841dc8335d" />



**After fix** 

<img width="1431" height="503" alt="Screenshot 2026-07-09 at 11 33 20 AM" src="https://github.com/user-attachments/assets/6eb68ed6-66ff-4f16-a46d-0c836d184fe9" />

