### PR TITLE
fix(tablecell): updated progress bar css

### DIFF
--- a/src/components/reusable/table/table-cell.scss
+++ b/src/components/reusable/table/table-cell.scss
@@ -17,12 +17,14 @@
 
 .slot-wrapper {
   display: inline-block;
-  width: 100%;
-  min-width: 0;
   max-width: 100%;
 }
 
-.slot-wrapper slot::slotted(*) {
+.has-progress {
+  width: 100%;
+}
+
+.slot-wrapper::slotted(*) {
   display: flex;
   min-width: 0;
   flex-shrink: 1;

--- a/src/components/reusable/table/table-cell.ts
+++ b/src/components/reusable/table/table-cell.ts
@@ -1,5 +1,6 @@
 import { html, LitElement, PropertyValues, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { ContextConsumer } from '@lit/context';
 import { tableContext, TableContextType } from './table-context';
 
@@ -63,6 +64,9 @@ export class TableCell extends LitElement {
   @property({ type: Boolean, reflect: true })
   accessor dimmed = false;
 
+  @state()
+  private accessor hasProgressBarComponent = false;
+
   /**
    * Context consumer for the table context.
    * Updates the cell's dense properties when the context changes.
@@ -104,11 +108,35 @@ export class TableCell extends LitElement {
     if (this.minWidth && changedProperties.has('minWidth')) {
       this.style.setProperty('--kyn-td-min-width', this.minWidth);
     }
+
+    this.applyProgressBarStyles();
+  }
+
+  private applyProgressBarStyles() {
+    const slot = this.shadowRoot?.querySelector('slot');
+    if (!slot) return;
+
+    const assignedElements = slot?.assignedElements();
+    let hasProgress = false;
+
+    assignedElements.forEach((el) => {
+      const tagName = el?.tagName?.toLowerCase();
+      if (tagName === 'kyn-progress-bar') {
+        hasProgress = true;
+      }
+    });
+
+    this.hasProgressBarComponent = hasProgress;
   }
 
   override render() {
     return html`
-      <div class="slot-wrapper">
+      <div
+        class=${classMap({
+          'slot-wrapper': true,
+          'has-progress': this.hasProgressBarComponent,
+        })}
+      >
         <slot></slot>
       </div>
     `;


### PR DESCRIPTION
## Summary

https://github.com/kyndryl-design-system/shidoka-applications/issues/908 , fix was breaking first and last column alignment 
Refer : https://shidoka-applications.netlify.app/?path=/story/components-data-display-data-table--bulk-selection (checkbox column  and last column)
https://shidoka-applications.netlify.app/?path=/story/components-data-display-data-table--stacked-header(checkbox column)

Handled the fix via logically by checking slotted kyn-progress-bar in <kyn-td> cell.


## GitHub Issue 

https://github.com/kyndryl-design-system/shidoka-applications/issues/915


## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## Screenshots

<img width="1170" height="468" alt="Screenshot 2026-07-14 at 4 49 42 PM" src="https://github.com/user-attachments/assets/4a8c1084-f6b3-49c5-a883-438c6b4f45ba" />


<img width="729" height="478" alt="Screenshot 2026-07-14 at 4 49 52 PM" src="https://github.com/user-attachments/assets/268702ca-98dc-43a3-ab5e-d290da2048d8" />

<img width="757" height="427" alt="Screenshot 2026-07-14 at 4 49 59 PM" src="https://github.com/user-attachments/assets/163befb6-f152-484e-8b3c-4e9916f4b9e1" />


