### PR TITLE
docs: update GitBook link in welcome page

### DIFF
--- a/src/stories/welcome.mdx
+++ b/src/stories/welcome.mdx
@@ -12,7 +12,7 @@ View the [Readme here](https://github.com/kyndryl-design-system/shidoka-applicat
 
 ## Full Documentation & Guidelines
 
-[Shidoka GitBook](https://kyndryl.gitbook.io/kyndryl-cto/shidoka-design-system)
+[Shidoka GitBook](https://kyndryl.gitbook.io/shidoka-design-system)
 
 ## Foundation
 


### PR DESCRIPTION
Replace outdated kyndryl-cto GitBook URL with the current Shidoka design system documentation site.
