### PR TITLE
fix(daterangestyle): style injection trial fix

### DIFF
--- a/src/common/helpers/flatpickr/flatpickr.ts
+++ b/src/common/helpers/flatpickr/flatpickr.ts
@@ -188,14 +188,20 @@ export function ensureFlatpickrStylesInRoot(
   calendarStyle: string,
   fallbackNode?: Node | null
 ): void {
-  if (!node || !calendarStyle) return;
+  if (!calendarStyle || (!node && !fallbackNode)) return;
 
-  const nodeRoot = (node as { getRootNode?: () => Node }).getRootNode?.();
+  const nodeRoot = node
+    ? (node as { getRootNode?: () => Node }).getRootNode?.()
+    : undefined;
   const fallbackRoot =
     fallbackNode &&
     (fallbackNode as { getRootNode?: () => Node }).getRootNode?.();
-  const root = nodeRoot instanceof ShadowRoot ? nodeRoot : fallbackRoot;
-  if (!(root instanceof ShadowRoot)) return;
+
+  // Prefer the overlay/modal root when provided; otherwise use the calendar node root.
+  const root =
+    (fallbackRoot instanceof ShadowRoot && fallbackRoot) ||
+    (nodeRoot instanceof ShadowRoot ? nodeRoot : null);
+  if (!root) return;
 
   const cachedThemeStyle = flatpickrStyledRoots.get(root);
   if (

--- a/src/common/helpers/flatpickr/flatpickr.ts
+++ b/src/common/helpers/flatpickr/flatpickr.ts
@@ -230,6 +230,7 @@ export function ensureFlatpickrStylesInRoot(
   styleElement.textContent = calendarStyle;
   root.appendChild(styleElement);
   flatpickrStyledRoots.set(root, styleElement);
+  console.log('Testing pickr');
 }
 
 export async function initializeMultiAnchorFlatpickr(

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -1359,7 +1359,6 @@ export class DateRangePicker extends FormMixin(LitElement) {
 
     const container = getModalContainer(this);
     // Pre-inject right before Flatpickr init/reinit
-    console.log('testing pickr1');
     ensureFlatpickrStylesInRoot(
       inputEl,
       ShidokaFlatpickrCalendarTheme.toString(),

--- a/src/components/reusable/daterangepicker/daterangepicker.ts
+++ b/src/components/reusable/daterangepicker/daterangepicker.ts
@@ -1357,6 +1357,15 @@ export class DateRangePicker extends FormMixin(LitElement) {
     const inputEl = this._inputEl;
     this._pendingFlatpickrReinit = false;
 
+    const container = getModalContainer(this);
+    // Pre-inject right before Flatpickr init/reinit
+    console.log('testing pickr1');
+    ensureFlatpickrStylesInRoot(
+      inputEl,
+      ShidokaFlatpickrCalendarTheme.toString(),
+      container
+    );
+
     try {
       cleanupFlatpickrInstance(this.flatpickrInstance);
       this.flatpickrInstance = undefined;


### PR DESCRIPTION
## Summary, 2nd Trial , Not very sure how it actually behaves on Console 📱. 

Pre-inject styles right before Flatpickr init/reinit +  for nested shadow-dom , injected styles right before parent component.

## before flatpickr style getting added inside kyn-date-range-picker  component 

<img width="1069" height="612" alt="image" src="https://github.com/user-attachments/assets/5e4808c3-f8f7-4e93-a6df-95f84eccffa5" />




## Now adding right before parent component 

<img width="1109" height="602" alt="image" src="https://github.com/user-attachments/assets/cce29ede-b0e5-4b9a-a09d-39d2dbc2c8da" />






## GitHub Issue Link

Link here (if applicable).

## Figma Link

Link here (if applicable).

## Notes

- Detailed change notes
- can go here

## To Do

- Anything else
- left to do

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Testing Instructions

Provide guidance to reviewers/testers here.

## Screenshots

(if any)
