### PR TITLE
chore(ci): add explicit workflow permissions for least privilege

### DIFF
--- a/.github/workflows/ado-issue-sync.yml
+++ b/.github/workflows/ado-issue-sync.yml
@@ -11,6 +11,9 @@ concurrency:
   group: issue-${{ github.event.issue.number }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   alert:
     if: ${{ !github.event.issue.pull_request }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   GH_TOKEN: '${{ secrets.GH_TOKEN }}'
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,6 +7,10 @@ on:
       - next
   pull_request:
     types: [review_requested]
+
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
   Release:
     needs: [Build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to GitHub Actions workflows flagged by CodeQL (`actions/missing-workflow-permissions`)
- Scope build, test, Chromatic, and ADO sync workflows to `contents: read`
- Elevate write permissions only on the `Release` job (`contents: write`, `issues: write`, `id-token: write`) so semantic-release can still tag and publish